### PR TITLE
fix: document ScreenShare run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,47 @@ ScreenShare is a great demo tool that allows you to mirror your iOS devices to y
   - Live demos in front of thousands of people.
 
 ![ScreenShare streaming](https://garethjones-apps.s3.amazonaws.com/apps/screenshare/screenshot.png)
+
+## Running the Project
+
+ScreenShare is a macOS Xcode project. The app runs on your Mac and displays a connected iPhone or iPad as a capture device.
+
+### Prerequisites
+
+- A Mac with Xcode installed.
+- An iPhone or iPad connected to the Mac over USB and unlocked.
+- An Xcode toolchain that can open or migrate a Swift 2.3 project.
+
+The project was last configured for macOS 10.9 and Swift 2.3. Modern versions of Xcode may prompt you to migrate the Swift source before the app can build.
+
+### Run from Xcode
+
+1. Clone or download the repository.
+2. Open `Screenshare.xcodeproj` in Xcode.
+3. Select the `Screenshare` scheme.
+4. Choose `My Mac` as the run destination.
+5. Connect and unlock the iOS device you want to mirror.
+6. Press Run.
+
+When the app launches, it scans for connected iOS capture devices. If a device is detected, ScreenShare opens a window using the matching phone or tablet frame.
+
+### Command-Line Build Check
+
+If your Xcode installation supports this project, you can also run the existing test wrapper:
+
+```sh
+./build.sh
+```
+
+That script runs:
+
+```sh
+xcodebuild -project Screenshare.xcodeproj -scheme "Screenshare" -destination "platform=OS X" test
+```
+
+### Troubleshooting
+
+- If Xcode cannot compile the project, check whether it is asking to migrate the Swift 2.3 sources.
+- If Xcode reports a signing error, select the `Screenshare` target and choose a valid macOS development team or local signing identity.
+- If the Run button is disabled, make sure the `Screenshare` scheme and `My Mac` destination are selected.
+- If no device window appears, reconnect the iPhone or iPad, unlock it, and confirm the device is visible to macOS before running the app again.

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-function ci_lib() {
+ci_lib() {
     xcodebuild -project Screenshare.xcodeproj \
                -scheme "Screenshare" \
                -destination "platform=OS X" \


### PR DESCRIPTION
## Summary

Developers get concrete instructions for opening and running the legacy ScreenShare project, and its build script now executes correctly under the shell interpreter it declares.

## Baseline

The repository did not explain the Xcode project, scheme, target, Swift 2.3 migration requirement, or common first-run issues, while `build.sh` used syntax incompatible with its declared `/bin/sh` interpreter. This PR is currently `CONFLICTING`/`DIRTY` against `master`, has no hosted checks, and could not reach an Xcode build in this workspace.

## Improvements

- add README instructions for opening and running `Screenshare.xcodeproj`
- document the legacy Swift 2.3/Xcode migration caveat and common first-run troubleshooting
- fix `build.sh` so it is valid under its declared `/bin/sh` interpreter

## Validation

- `rg -n "Running the Project|Screenshare\.xcodeproj|Swift 2\.3|build\.sh|My Mac|Screenshare scheme" README.md`
- `git diff --check`
- `./build.sh` now reaches the Xcode invocation; this workspace does not have `xcodebuild`, so it stops with `xcodebuild: not found`

No hosted checks, Xcode compilation, application launch, or screen-sharing workflow validation are reported for this PR.

## Risk

- The branch is currently conflicting with `master`, so the final integrated documentation and script behavior are not proven.
- Swift 2.3 and its compatible Xcode versions are obsolete and may not run on current macOS releases without migration.
- Shell syntax validity does not prove the selected Xcode project, scheme, destination, signing, or framework dependencies build successfully.
- First-run permissions and screen-capture behavior can vary by macOS version and are not exercised here.

## Follow-Ups

- Resolve conflicts against current `master` while preserving newer documentation and build changes.
- Run `./build.sh` and open `Screenshare.xcodeproj` with a documented compatible Xcode/macOS combination.
- Verify scheme selection, compilation, launch, screen-capture permissions, display selection, and a representative sharing session.
- Decide whether to preserve the project as a historical sample or plan an explicit Swift and macOS API migration.

Closes #6
