### PR TITLE
fix(settings): remove device initializer force unwrap

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-12
 
+- Made live capture-device settings construction nonfailable and removed its
+  forced result unwrap while preserving failable archive decoding.
 - Guarded `Skin` application-delegate lookup and made selection and settings
   coordination tolerate unavailable delegate lifecycle state.
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   signing disabled.
 - Static behavior checks also guard local device-settings archive decoding
   against force-cast crashes.
+- Static behavior checks require live capture-device settings construction to
+  be nonfailable and force-unwrap-free.
 - Static behavior checks also reject debug logging of device names and saved
   window rectangles from local settings.
 - Static behavior checks also keep missing local settings from clearing the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,6 +39,8 @@ Helpful reports include:
   capture UI is not retained or updated after teardown.
 - Capture skins must conditionally resolve the application delegate so unusual
   nib or application lifecycle state cannot trigger a force-cast crash.
+- Newly discovered capture devices must create settings without a failable
+  initializer or forced result unwrap; malformed archives remain fail-closed.
 
 ## Mobile Privacy Notes
 

--- a/ScreenShare/AppDelegate.swift
+++ b/ScreenShare/AppDelegate.swift
@@ -67,7 +67,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             }
         }
         
-        let newDevice = Device(fromDevice: device)!
+        let newDevice = Device(fromDevice: device)
         self.deviceSettings.append(newDevice)
         return newDevice
     }

--- a/ScreenShare/Device.swift
+++ b/ScreenShare/Device.swift
@@ -32,7 +32,7 @@ class Device: NSObject, NSCoding {
     
     static let ArchivePath = NSHomeDirectory().appending("/devices")
 
-    convenience init?(fromDevice device: AVCaptureDevice) {
+    convenience init(fromDevice device: AVCaptureDevice) {
         self.init(name: device.localizedName, uid: device.uniqueID, portraitRect:NSRect(), landscapeRect:NSRect())
     }
     init(name: String, uid: String, portraitRect:NSRect, landscapeRect:NSRect) {

--- a/VISION.md
+++ b/VISION.md
@@ -18,6 +18,7 @@ Priority:
 - Keep single-device limitations visible
 - Handle capture runtime errors without crashing on malformed notifications
 - Decode local device settings without force-cast launch crashes
+- Create settings for newly discovered capture devices without force unwraps
 - Keep saved device settings separate from active capture-device discovery
 - Avoid logging local device names or saved window rectangles
 - Avoid ad hoc stdout logging from app Swift sources

--- a/docs/plans/2026-06-12-device-settings-initializer.md
+++ b/docs/plans/2026-06-12-device-settings-initializer.md
@@ -1,0 +1,76 @@
+# Device Settings Initializer
+
+## Status: Completed
+
+## Context
+
+`Device(fromDevice:)` is declared failable even though it only forwards the
+capture device's name and unique identifier to a nonfailable initializer.
+`AppDelegate.findDeviceSettings` compensates by force-unwrapping the result,
+creating an unnecessary crash surface when a newly discovered device has no
+saved settings.
+
+## Requirements
+
+- R1. Make capture-device settings construction nonfailable.
+- R2. Remove the force unwrap from new device-settings creation.
+- R3. Preserve archive decoding as failable for malformed saved data.
+- R4. Preserve device lookup, append, and return behavior.
+- R5. Add source contracts, focused hostile mutations, documentation, and full
+  `make check` verification.
+
+## Scope Boundaries
+
+- Do not change device discovery, archive format, or saved window geometry.
+- Do not alter capture session or application-delegate ownership behavior.
+- Do not claim connected-device runtime verification without compatible macOS
+  hardware and an attached iOS capture device.
+
+## Implementation Units
+
+### Nonfailable live-device construction
+
+**Files:** `ScreenShare/Device.swift`, `ScreenShare/AppDelegate.swift`
+
+- Remove optionality from the live `AVCaptureDevice` convenience initializer.
+- Construct and append new settings without a force unwrap.
+
+### Regression contract and maintenance record
+
+**Files:** `scripts/check-screenshare-source.py`, `README.md`, `SECURITY.md`,
+`VISION.md`, `CHANGES.md`, `docs/plans/2026-06-12-device-settings-initializer.md`
+
+- Reject failable live-device construction and forced result unwrapping while
+  retaining failable archive decoding.
+
+## Verification Plan
+
+- `python3 scripts/check-screenshare-source.py --mode behavior`
+- `make check`
+- focused initializer mutations
+- `git diff --check`
+- exact-head hosted unsigned macOS build before merge
+
+## Work Completed
+
+- Made the live `AVCaptureDevice` convenience initializer nonfailable.
+- Removed the forced initializer result unwrap while preserving settings lookup,
+  append, and return behavior.
+- Kept `NSCoding` archive restoration failable and optional-bound for malformed
+  saved data.
+- Extended source contracts and maintenance guidance for both initializer
+  domains.
+
+## Verification
+
+- `python3 scripts/check-screenshare-source.py --mode behavior` passed.
+- Four focused hostile initializer mutations were rejected.
+- `make check` passed; local Xcode compilation was unavailable on Linux and the
+  Makefile ran its documented static-only path.
+- An external-directory repository Makefile invocation passed from `/tmp`.
+- `git diff --check` passed.
+
+## Remaining Risks
+
+- Static checks and compilation do not exercise real device connection,
+  disconnection, or archived settings recovery.

--- a/scripts/check-screenshare-source.py
+++ b/scripts/check-screenshare-source.py
@@ -200,6 +200,16 @@ def behavior_checks():
         errors.append("Device archive decoding must not force-cast saved settings")
     if "guard let name = aDecoder.decodeObject(forKey: PropertyKey.nameKey) as? String" not in device:
         errors.append("Device archive decoding must optional-bind saved settings fields")
+    if "required convenience init?(coder aDecoder: NSCoder)" not in device:
+        errors.append("Device archive decoding must remain failable for malformed saved settings")
+    if "convenience init?(fromDevice device: AVCaptureDevice)" in device:
+        errors.append("Live capture-device settings construction must not be failable")
+    if "convenience init(fromDevice device: AVCaptureDevice)" not in device:
+        errors.append("Device must expose nonfailable live capture-device settings construction")
+    if "Device(fromDevice: device)!" in app_delegate:
+        errors.append("AppDelegate must not force unwrap live device-settings construction")
+    if "let newDevice = Device(fromDevice: device)\n        self.deviceSettings.append(newDevice)\n        return newDevice" not in app_delegate:
+        errors.append("AppDelegate must append and return newly constructed device settings")
     if "dimensions.height != dimensions.height" in document:
         errors.append("Document.updateAspect must not compare dimensions.height to itself")
     if "dimensions.height != self.videoDimensions.height" not in document:


### PR DESCRIPTION
## Summary

Newly discovered capture devices can no longer hit a forced optional unwrap while creating their initial saved-settings record. Live `AVCaptureDevice` construction is now nonfailable, while keyed-archive restoration remains failable and guarded so malformed persisted data still fails closed.

## Baseline

Creating the first saved-settings record for a newly discovered live capture device treated construction as optional and force-unwrapped the result, creating a crash path. Persisted keyed-archive data must remain failable because malformed stored data cannot be trusted. This is a stacked successor targeting the existing ScreenShare remediation branch rather than the default branch.

## Improvements

- make live `AVCaptureDevice` settings construction nonfailable
- remove the forced optional result from first-time settings creation
- keep keyed-archive restoration failable and guarded
- preserve device lookup, append, return, and archive-format behavior

## Validation

- `make check`
- external-directory repository Makefile check from `/tmp`
- four focused hostile mutations covering live initializer optionality, forced results, settings append, and archive decoder optionality
- `git diff --check` and focused secret-marker scan
- hosted `contract` and unsigned macOS `build` checks succeeded

## Risk

- This stacked PR depends on the existing ScreenShare remediation branch and must be integrated in the correct order.
- Local Xcode execution is unavailable on Linux, so discovery of a previously unseen device still requires a compatible macOS manual test.
- Persisted archive restoration intentionally remains failable; malformed saved data may be rejected rather than recovered.
- The local sample app has no production telemetry or deployed monitoring service.

## Follow-Ups

- Connect a previously unseen iOS capture device on a compatible macOS host and confirm settings creation without a crash.
- Verify existing archived settings still decode and malformed archives continue to fail closed.
- Treat any hosted build failure or device-connection crash as a rollback trigger before merge.

## Post-Deploy Monitoring & Validation

No production monitoring is available or required for this local sample app. During the PR validation window, the maintainer owns exact-head GitHub Actions contract and hosted macOS build verification; a compatible macOS manual run should connect a previously unseen iOS capture device and confirm settings creation without a crash. Any hosted build failure or device-connection crash is a rollback trigger before merge.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
