### PR TITLE
fix(capture): roll back rejected device switches

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-13
+
+- Added capture device switch rollback so rejected replacements restore the
+  prior working input inside one session configuration transaction.
+
 ## 2026-06-12
 
 - Made live capture-device settings construction nonfailable and removed its

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   width and height against the stored dimensions.
 - Static behavior checks also require capture input setup failures to handle
   missing `NSError` metadata without force unwrapping.
+- Static behavior checks require capture device switch rollback: replacement
+  inputs are prepared and validated before a failed switch restores the prior
+  working input.
 - Static behavior checks also require document preview setup and aspect updates
   to optional-bind outlets, backing layers, input ports, and windows.
 - Static behavior checks also require session window setup to avoid
@@ -131,6 +134,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   missing-settings device-list guard.
 - See `docs/plans/2026-06-09-capture-input-error-guard.md` for the capture
   input error metadata guard.
+- See `docs/plans/2026-06-13-device-switch-rollback.md` for capture device
+  switch rollback and single-transaction session configuration.
 - See `docs/plans/2026-06-09-document-preview-guard.md` for the document
   preview and aspect optional-binding guard.
 - See `docs/plans/2026-06-09-session-window-setup-guard.md` for the session

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,6 +41,8 @@ Helpful reports include:
   nib or application lifecycle state cannot trigger a force-cast crash.
 - Newly discovered capture devices must create settings without a failable
   initializer or forced result unwrap; malformed archives remain fail-closed.
+- Capture device switch rollback must restore the prior working input when a
+  replacement cannot be admitted, without logging device metadata.
 
 ## Mobile Privacy Notes
 

--- a/ScreenShare/Document.swift
+++ b/ScreenShare/Document.swift
@@ -91,13 +91,9 @@ class Document: NSDocument {
         self.devices = AVCaptureDevice.devices(for: .video)
             + AVCaptureDevice.devices(for: .muxed)
         
-        self.session.beginConfiguration()
-        
         if let selectedDevice = self.selectedDevice, !self.devices.contains(selectedDevice) {
             self.selectedDevice = nil
         }
-        
-        self.session.commitConfiguration()
         
     }
     
@@ -106,28 +102,47 @@ class Document: NSDocument {
             return self.input?.device
         }
         set {
-            self.session.beginConfiguration()
-            
-            if let input = self.input {
-                session.removeInput(input)
-                self.input = nil
-            }
-            
+            let replacementInput: AVCaptureDeviceInput?
             if let newDevice = newValue {
                 do {
-                    let newDeviceInput = try AVCaptureDeviceInput(device: newDevice)
-                    self.session.sessionPreset = .high
-                    self.session.addInput(newDeviceInput)
-                    self.input = newDeviceInput
+                    replacementInput = try AVCaptureDeviceInput(device: newDevice)
                 } catch let error as NSError {
                     self.displayError(error: error)
+                    return
                 }
-                
+            } else {
+                replacementInput = nil
             }
-            
-            self.session.commitConfiguration()
-            
-            self.updateAspect()
+
+            self.session.beginConfiguration()
+            defer {
+                self.session.commitConfiguration()
+                self.updateAspect()
+            }
+
+            let previousInput = self.input
+            if let previousInput = previousInput {
+                self.session.removeInput(previousInput)
+            }
+            self.input = nil
+
+            guard let replacementInput = replacementInput else {
+                return
+            }
+
+            self.session.sessionPreset = .high
+            guard self.session.canAddInput(replacementInput) else {
+                if let previousInput = previousInput,
+                    self.session.canAddInput(previousInput) {
+                    self.session.addInput(previousInput)
+                    self.input = previousInput
+                }
+                NSLog("Capture session rejected the replacement device input.")
+                return
+            }
+
+            self.session.addInput(replacementInput)
+            self.input = replacementInput
         }
     }
     

--- a/VISION.md
+++ b/VISION.md
@@ -23,6 +23,7 @@ Priority:
 - Avoid logging local device names or saved window rectangles
 - Avoid ad hoc stdout logging from app Swift sources
 - Handle capture input setup failures without force-unwrapping error metadata
+- Preserve capture device switch rollback when replacement admission fails
 - Keep preview aspect updates responsive to width and height changes
 - Keep document preview and aspect setup tolerant of missing nib or capture state
 - Release repeating preview timers when document windows close

--- a/docs/plans/2026-06-13-device-switch-rollback.md
+++ b/docs/plans/2026-06-13-device-switch-rollback.md
@@ -1,0 +1,62 @@
+# Capture Device Switch Rollback
+
+## Status: Completed
+
+## Context
+
+`Document.selectedDevice` removed the active capture input before constructing
+the replacement and called `addInput` without `canAddInput`. Construction or
+session-admission failure could therefore leave a previously working preview
+without any input. Device refresh also wrapped the setter in a second session
+configuration transaction.
+
+## Priority
+
+Capture device switching should be transactional. A failed replacement must
+not destroy the current working session, and session configuration should not
+depend on nested begin/commit calls.
+
+## Objectives
+
+- Construct the replacement input before mutating the session.
+- Use one begin/commit configuration transaction per switch.
+- Check `canAddInput` before adding a replacement.
+- Restore the previous input when replacement admission fails.
+- Log a fixed diagnostic without exposing device names or identifiers.
+- Add fail-closed source, documentation, and completed-plan contracts.
+
+## Work Completed
+
+- Prepared replacement inputs before capture-session mutation.
+- Centralized commit and aspect refresh in a `defer` block.
+- Added replacement admission validation and prior-input rollback.
+- Removed nested session configuration from device refresh.
+- Extended the static checker and project guidance.
+
+## Verification
+
+- `python3 scripts/check-screenshare-source.py --mode behavior`
+- `make check` locally and from outside the repository root
+- focused construction, admission, rollback, transaction, documentation, and
+  plan mutations
+- Python checker compilation, plist/asset parsing, Swift delimiter, secret,
+  artifact, and `git diff --check` audits
+- hosted unsigned macOS compilation; connected-device behavior remains manual
+
+Project and behavior checks plus full `make check` passed locally with the
+documented static-only path because `xcodebuild` is unavailable. All six
+construction, admission, rollback, transaction, documentation, and plan
+mutation categories were rejected.
+
+The app plist, entitlements, both README SVG files, and all nine asset JSON
+manifests parsed successfully. Python checker compilation, high-confidence
+secret screening, and `git diff --check` passed. Checker compilation created an
+ignored `scripts/__pycache__` artifact; it is excluded from the explicit-path
+commit and preserved. Hosted unsigned compilation remains required on the
+exact PR head.
+
+## Scope Boundary
+
+This preserves the prior input when a replacement is rejected. It does not
+exercise connected iOS hardware, capture output, mirroring latency, or device
+disconnect timing in hosted CI.

--- a/scripts/check-screenshare-source.py
+++ b/scripts/check-screenshare-source.py
@@ -11,6 +11,7 @@ DOCS_PLANS = ROOT / "docs" / "plans"
 CANONICAL_PLAN = DOCS_PLANS / "2026-06-08-screenshare-baseline.md"
 DOCUMENT_PREVIEW_PLAN = DOCS_PLANS / "2026-06-09-document-preview-guard.md"
 CI_PLAN = DOCS_PLANS / "2026-06-10-ci-baseline.md"
+DEVICE_SWITCH_ROLLBACK_PLAN = DOCS_PLANS / "2026-06-13-device-switch-rollback.md"
 EXPECTED_WORKFLOW = """name: Check
 
 on:
@@ -99,6 +100,8 @@ def docs_plan_checks():
         errors.append("docs/plans/2026-06-09-document-preview-guard.md is missing")
     if not CI_PLAN.exists():
         errors.append("docs/plans/2026-06-10-ci-baseline.md is missing")
+    if not DEVICE_SWITCH_ROLLBACK_PLAN.exists():
+        errors.append("docs/plans/2026-06-13-device-switch-rollback.md is missing")
 
     plans = sorted(DOCS_PLANS.glob("*.md")) if DOCS_PLANS.exists() else []
     if not plans:
@@ -142,8 +145,11 @@ def project_checks():
             errors.append(f"Makefile is missing root-independent fragment: {fragment}")
 
     for doc_path in ("README.md", "VISION.md", "SECURITY.md", "CHANGES.md"):
-        if "GitHub Actions" not in read_text(doc_path):
+        document = re.sub(r"\s+", " ", read_text(doc_path))
+        if "GitHub Actions" not in document:
             errors.append(f"{doc_path} must document the GitHub Actions baseline")
+        if "capture device switch rollback" not in document.lower():
+            errors.append(f"{doc_path} must document capture device switch rollback")
 
     project = read_text("Screenshare.xcodeproj/project.pbxproj")
     for fragment in (
@@ -278,6 +284,19 @@ def behavior_checks():
         errors.append("AppDelegate.refreshDevices must guard the main device-list window outlet")
     if 'NSLog("Main device list window outlet is missing.")' not in app_delegate:
         errors.append("AppDelegate.refreshDevices must log a missing main window outlet")
+    refresh_devices = re.search(r"func refreshDevices\(\)\s*\{(?P<body>.*?)^    \}", document, re.DOTALL | re.MULTILINE)
+    if refresh_devices and "beginConfiguration()" in refresh_devices.group("body"):
+        errors.append("Document.refreshDevices must not nest capture session configuration")
+    if "let replacementInput: AVCaptureDeviceInput?" not in document or "replacementInput = try AVCaptureDeviceInput(device: newDevice)" not in document:
+        errors.append("Document.selectedDevice must construct the replacement input before mutating the session")
+    if "defer {\n                self.session.commitConfiguration()\n                self.updateAspect()\n            }" not in document:
+        errors.append("Document.selectedDevice must commit its single configuration transaction and refresh aspect state")
+    if "guard self.session.canAddInput(replacementInput) else" not in document:
+        errors.append("Document.selectedDevice must validate replacement input admission")
+    if "self.session.canAddInput(previousInput)" not in document or "self.session.addInput(previousInput)\n                    self.input = previousInput" not in document:
+        errors.append("Document.selectedDevice must restore the previous input when replacement admission fails")
+    if 'NSLog("Capture session rejected the replacement device input.")' not in document:
+        errors.append("Document.selectedDevice must log replacement rejection without device metadata")
 
     for swift_path in sorted((ROOT / "ScreenShare").glob("*.swift")):
         for line_number, line in enumerate(swift_path.read_text(encoding="utf-8").splitlines(), 1):


### PR DESCRIPTION
## Summary

Make capture-device switching transactional so a rejected replacement restores the previous working input.

## Baseline

This change is stacked on PR #9 (`lfg/screenshare-device-settings-initializer-20260612`) and preserves its capture-device settings initialization behavior.

## Improvements

- Construct the replacement capture input before modifying the active session.
- Check whether the session can admit the replacement input.
- Restore the previous working input when admission rejects the replacement.
- Avoid nested capture-session configuration calls during device refresh.
- Emit a fixed failure diagnostic without exposing device metadata.

## Validation

- Project and behavior source contracts.
- `make check` locally and through the repository Makefile path.
- Six focused construction, admission, rollback, transaction, documentation, and plan mutation categories.
- Plist, entitlement, SVG, and nine asset-manifest parses.
- Python checker compilation, secret screening, and `git diff --check`.
- Both hosted checks succeeded on the exact head.

## Risk

The hosted unsigned macOS build is required. Connected-device switching remains manual, so this evidence does not claim an end-to-end device-switch exercise with physical capture hardware.

## Follow-Ups

- Exercise accepted and rejected device switches with connected capture hardware when a suitable macOS test host is available.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
