### PR TITLE
Protect Make repository root from caller overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 PYTHON ?= python3
 XCODEBUILD ?= xcodebuild
-ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 lint:
 	sh -n "$(ROOT)/build.sh"

--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   switch rollback and single-transaction session configuration.
 - See `docs/plans/2026-06-13-device-archive-optional-binding.md` for the saved
   settings archive boundary.
+- See `docs/plans/2026-06-14-make-root-override-protection.md` for the
+  caller-resistant, location-independent ScreenShare validation root.
 - See `docs/plans/2026-06-09-document-preview-guard.md` for the document
   preview and aspect optional-binding guard.
 - See `docs/plans/2026-06-09-session-window-setup-guard.md` for the session

--- a/docs/plans/2026-06-14-make-root-override-protection.md
+++ b/docs/plans/2026-06-14-make-root-override-protection.md
@@ -1,6 +1,6 @@
 # Make Root Override Protection
 
-## Status: Planned
+## Status: Completed
 
 ## Context
 
@@ -52,3 +52,26 @@ hostile execution, Python 3.12 validation, mutations, and integrity screening.
 - root-declaration, checker, plan-status, README-index, and evidence mutations
 - Python/shell syntax, workflow YAML, protected-file, secret, artifact, and
   `git diff --check` gates
+
+## Work Completed
+
+- Protected the existing Makefile-derived repository root in place from
+  command-line and environment overrides.
+- Added exact-count, completed-evidence, and README-index contracts.
+- Preserved all Swift, shell, capture, settings, archive, project, workflow,
+  and hosted macOS build boundaries.
+
+## Verification Results
+
+- `python3 scripts/check-screenshare-source.py --mode project` and
+  `python3 scripts/check-screenshare-source.py --mode behavior` both passed.
+- From both the checkout and an external directory, all five public Make aliases passed.
+- `make ROOT=/tmp check` passed externally while still executing repository-owned
+  shell, project, and behavior contracts.
+- Python 3.12 passed the full static gate; local Xcode compilation was skipped
+  because `xcodebuild` was unavailable, leaving the hosted macOS build authoritative.
+- Six hostile mutations were rejected across root declaration, checker
+  expectation, plan status, README indexing, and recorded evidence.
+- Python and shell syntax, workflow YAML, exact-base protected-file comparison,
+  secret screening, generated-artifact screening, and `git diff --check`
+  passed before shipping.

--- a/docs/plans/2026-06-14-make-root-override-protection.md
+++ b/docs/plans/2026-06-14-make-root-override-protection.md
@@ -1,0 +1,54 @@
+# Make Root Override Protection
+
+## Status: Planned
+
+## Context
+
+The Makefile derives its repository root and uses that path for shell syntax,
+static source contracts, and conditional Xcode builds. GNU Make command-line
+variables outrank an ordinary assignment, so `make ROOT=/tmp check` can
+redirect those commands away from the checkout.
+
+## Requirements
+
+- **R1:** Prevent command-line and environment values from replacing the
+  Makefile-derived repository root.
+- **R2:** Keep `PYTHON` and `XCODEBUILD` configurable.
+- **R3:** Require exactly one protected root declaration in the source checker.
+- **R4:** Preserve the declaration's existing Makefile position while proving
+  every public alias from root and an external directory.
+- **R5:** Preserve capture, device settings, archive decoding, rollback,
+  workflow, signing, shell, and macOS build contracts.
+
+## Implementation Units
+
+### U1. Protected Root
+
+Give the existing repository-derived root assignment override precedence
+without reordering tool variables or changing recipes.
+
+### U2. ScreenShare Contract
+
+Extend `scripts/check-screenshare-source.py` to reject weakened, duplicate, or
+caller-controlled root declarations and incomplete evidence.
+
+### U3. Verification
+
+Run project and behavior contracts, shell syntax, all Make aliases, external
+hostile execution, Python 3.12 validation, mutations, and integrity screening.
+
+## Scope Boundary
+
+- Do not modify Swift, shell behavior, projects, schemes, or signing settings.
+- Do not change hosted actions, runners, Xcode build, or test coverage.
+- Do not add archives, recordings, DerivedData, caches, or credentials.
+
+## Verification
+
+- `python3 scripts/check-screenshare-source.py --mode project`
+- `python3 scripts/check-screenshare-source.py --mode behavior`
+- `make check`
+- external `make ROOT=/tmp check`
+- root-declaration, checker, plan-status, README-index, and evidence mutations
+- Python/shell syntax, workflow YAML, protected-file, secret, artifact, and
+  `git diff --check` gates

--- a/scripts/check-screenshare-source.py
+++ b/scripts/check-screenshare-source.py
@@ -13,6 +13,7 @@ DOCUMENT_PREVIEW_PLAN = DOCS_PLANS / "2026-06-09-document-preview-guard.md"
 CI_PLAN = DOCS_PLANS / "2026-06-10-ci-baseline.md"
 DEVICE_SWITCH_ROLLBACK_PLAN = DOCS_PLANS / "2026-06-13-device-switch-rollback.md"
 DEVICE_ARCHIVE_BINDING_PLAN = DOCS_PLANS / "2026-06-13-device-archive-optional-binding.md"
+MAKE_ROOT_PLAN = DOCS_PLANS / "2026-06-14-make-root-override-protection.md"
 EXPECTED_WORKFLOW = """name: Check
 
 on:
@@ -105,6 +106,8 @@ def docs_plan_checks():
         errors.append("docs/plans/2026-06-13-device-switch-rollback.md is missing")
     if not DEVICE_ARCHIVE_BINDING_PLAN.exists():
         errors.append("docs/plans/2026-06-13-device-archive-optional-binding.md is missing")
+    if not MAKE_ROOT_PLAN.exists():
+        errors.append("docs/plans/2026-06-14-make-root-override-protection.md is missing")
 
     plans = sorted(DOCS_PLANS.glob("*.md")) if DOCS_PLANS.exists() else []
     if not plans:
@@ -137,8 +140,18 @@ def project_checks():
         errors.append("GitHub Actions workflow must match the reviewed credential-free contract and macOS build baseline")
 
     makefile = read_text("Makefile")
+    root_declaration = "override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))"
+    root_assignments = [
+        line
+        for line in makefile.splitlines()
+        if re.match(r"^(?:override\s+)?ROOT\s*[:?+]?=", line)
+    ]
+    if root_assignments != [root_declaration]:
+        errors.append(
+            "Makefile must define exactly one protected repository-derived ROOT declaration"
+        )
     for fragment in (
-        "ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))",
+        root_declaration,
         '"$(ROOT)/build.sh"',
         '"$(ROOT)/scripts/check-screenshare-source.py"',
         '"$(ROOT)/Screenshare.xcodeproj"',
@@ -146,6 +159,22 @@ def project_checks():
     ):
         if fragment not in makefile:
             errors.append(f"Makefile is missing root-independent fragment: {fragment}")
+
+    if MAKE_ROOT_PLAN.exists():
+        root_plan = MAKE_ROOT_PLAN.read_text(encoding="utf-8")
+        for evidence in (
+            "Status: Completed",
+            "`make ROOT=/tmp check` passed",
+            "all five public Make aliases passed",
+            "Six hostile mutations were rejected",
+            "Python 3.12",
+        ):
+            if evidence not in root_plan:
+                errors.append(
+                    f"{MAKE_ROOT_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}"
+                )
+        if str(MAKE_ROOT_PLAN.relative_to(ROOT)) not in read_text("README.md"):
+            errors.append(f"README.md must reference {MAKE_ROOT_PLAN.relative_to(ROOT)}")
 
     for doc_path in ("README.md", "VISION.md", "SECURITY.md", "CHANGES.md"):
         document = re.sub(r"\s+", " ", read_text(doc_path))


### PR DESCRIPTION
## Summary

- prevent callers from replacing the Makefile-derived ScreenShare validation root
- preserve the root declaration position while enforcing exactly one protected assignment
- require completed evidence and the README plan index

## Baseline

Command-line or environment input could replace the Makefile-derived ScreenShare validation root, allowing verification commands to resolve project files outside the checked-out repository.

## Improvements

The validation root is now protected from caller overrides while retaining its required declaration position and exactly-one assignment contract. Completed verification evidence and the README plan index are enforced with it.

## Validation

- project, behavior, and POSIX shell syntax contracts
- all five Make aliases from root and externally with `ROOT=/tmp`
- Python 3.12 read-only, network-disabled static snapshot
- six isolated declaration/checker/plan/README/evidence mutations rejected
- workflow, diff, secret, artifact, and protected-path integrity gates

Local `xcodebuild` was unavailable; the unchanged macOS hosted build job remains authoritative for compilation.

## Risk

Compilation was not run locally because `xcodebuild` was unavailable. The exact-head hosted contract and macOS build checks succeeded, and the change is limited to validation-root integrity and its enforcement evidence.

## Follow-Ups

Run the build locally on a compatible macOS/Xcode host when available. Future Makefile changes should preserve both the protected root assignment and its required declaration position.
