### PR TITLE
Guard Skin preview and window lifecycle

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-14
+
+- Added Skin preview and window guards instead of force unwrapping optional
+  AppKit outlets and resize-window lifecycle state.
+
 ## 2026-06-13
 
 - Replaced checked device-settings archive force unwrapping with device archive

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   working input.
 - Static behavior checks also require document preview setup and aspect updates
   to optional-bind outlets, backing layers, input ports, and windows.
+- Skin preview and window guards optional-bind preview layers and resize-window
+  lifecycle state instead of force unwrapping AppKit outlets.
 - Static behavior checks also require session window setup to avoid
   force-unwrapping the main screen or content view.
 - Static behavior checks also require device refreshes to guard the main
@@ -142,6 +144,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   settings archive boundary.
 - See `docs/plans/2026-06-14-make-root-override-protection.md` for the
   caller-resistant, location-independent ScreenShare validation root.
+- See `docs/plans/2026-06-14-skin-preview-window-guards.md` for guarded Skin
+  preview-layer and resize-window lifecycle setup.
 - See `docs/plans/2026-06-09-document-preview-guard.md` for the document
   preview and aspect optional-binding guard.
 - See `docs/plans/2026-06-09-session-window-setup-guard.md` for the session

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,6 +24,9 @@ Helpful reports include:
 
 ## Project Security Posture
 
+Skin preview and window guards must optional-bind AppKit outlets and lifecycle
+state before capture UI setup or resize handling.
+
 - This repository appears to be an Apple platform application or Swift sample. The active security scope is the code and documentation on the default branch.
 - Review found authentication, token, or session-related code paths; changes in those areas should receive security-focused review before merge.
 - Review found network clients, sockets, web APIs, or service endpoints; changes in those areas should receive security-focused review before merge.

--- a/ScreenShare/Skin.swift
+++ b/ScreenShare/Skin.swift
@@ -98,26 +98,36 @@ class Skin: NSView {
             self.addSubview(self.view)
             
             // Custom view set to render concurrently in order to have its own layer
-            let previewViewLayer = self.previewView.layer
-            previewViewLayer!.backgroundColor = CGColor.black
+            guard let previewView = self.previewView,
+                  let previewViewLayer = previewView.layer else {
+                NSLog("Skin preview outlet or backing layer is unavailable.")
+                return
+            }
+            previewViewLayer.backgroundColor = CGColor.black
             
             /* ADDING CONNECTION LATER            self.videoPreviewLayer = AVCaptureVideoPreviewLayer(sessionWithNoConnection: self.session) */
-            self.videoPreviewLayer = AVCaptureVideoPreviewLayer(session: self.session)
+            let videoPreviewLayer = AVCaptureVideoPreviewLayer(session: self.session)
+            self.videoPreviewLayer = videoPreviewLayer
+
+            videoPreviewLayer.frame = previewViewLayer.bounds
+            videoPreviewLayer.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
+            videoPreviewLayer.videoGravity = .resizeAspect
+
+            previewViewLayer.addSublayer(videoPreviewLayer)
             
-            self.videoPreviewLayer!.frame = previewViewLayer!.bounds
-            self.videoPreviewLayer!.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
-            self.videoPreviewLayer!.videoGravity = .resizeAspect
-            
-            previewViewLayer?.addSublayer(self.videoPreviewLayer!)
-            
-            originalPreviewViewBounds = self.previewView.bounds
+            originalPreviewViewBounds = previewView.bounds
         }
     }
     
     func registerNotifications() {
+        guard let window = self.window else {
+            NSLog("Skin notification window is unavailable.")
+            return
+        }
         self.notifications.registerObserver(
-            NSWindow.didResizeNotification, forObject: self.window!, dispatchAsyncToMainQueue: true, block: {note in
-                self.updateViewsToWindow(windowSize: self.window!.frame.size)
+            NSWindow.didResizeNotification, forObject: window, dispatchAsyncToMainQueue: true, block: { [weak self, weak window] _ in
+                guard let self = self, let window = window else { return }
+                self.updateViewsToWindow(windowSize: window.frame.size)
         })
     }
     
@@ -126,16 +136,21 @@ class Skin: NSView {
         self.session = AVCaptureSession()
         
         // Custom view set to render concurrently in order to have its own layer
-        let previewViewLayer = self.previewView.layer
-        previewViewLayer!.backgroundColor = CGColor.white
+        guard let previewView = self.previewView,
+              let previewViewLayer = previewView.layer else {
+            NSLog("Skin preview outlet or backing layer is unavailable.")
+            return
+        }
+        previewViewLayer.backgroundColor = CGColor.white
         
         /* ADDING CONNECTION LATER        self.videoPreviewLayer = AVCaptureVideoPreviewLayer(sessionWithNoConnection: self.session) */
-        self.videoPreviewLayer = AVCaptureVideoPreviewLayer(session: self.session)
-        
-        self.videoPreviewLayer!.frame = previewViewLayer!.bounds
+        let videoPreviewLayer = AVCaptureVideoPreviewLayer(session: self.session)
+        self.videoPreviewLayer = videoPreviewLayer
+
+        videoPreviewLayer.frame = previewViewLayer.bounds
         //newPreviewLayer.autoresizingMask = CAAutoresizingMask.LayerWidthSizable | CAAutoresizingMask.LayerHeightSizable
-        self.videoPreviewLayer!.videoGravity = .resize
-        previewViewLayer?.addSublayer(self.videoPreviewLayer!)
+        videoPreviewLayer.videoGravity = .resize
+        previewViewLayer.addSublayer(videoPreviewLayer)
         
         
         self.selectedDevice = device

--- a/VISION.md
+++ b/VISION.md
@@ -27,6 +27,7 @@ Priority:
 - Preserve capture device switch rollback when replacement admission fails
 - Keep preview aspect updates responsive to width and height changes
 - Keep document preview and aspect setup tolerant of missing nib or capture state
+- Keep Skin preview and window guards across AppKit lifecycle gaps
 - Release repeating preview timers when document windows close
 - Keep session window setup tolerant of missing screen or content-view state
 - Keep device refreshes tolerant of missing main window outlet state

--- a/docs/plans/2026-06-14-skin-preview-window-guards.md
+++ b/docs/plans/2026-06-14-skin-preview-window-guards.md
@@ -1,0 +1,31 @@
+# Skin Preview And Window Guards
+
+## Status: Planned
+
+## Context
+
+`Skin.loadSkinFromNib()` force unwraps the preview backing layer and generated
+video preview layer, while `registerNotifications()` force unwraps the owning
+window both when registering and when handling resize events. Missing or late
+IBOutlet/window state can therefore crash instead of failing closed.
+
+## Priority
+
+High capture UI reliability. Legacy nib and window lifecycle boundaries must
+not crash the process when optional AppKit state is unavailable.
+
+## Requirements
+
+- Guard the preview outlet and backing layer before configuring video preview.
+- Use a locally created preview layer without force unwrapping optional state.
+- Guard the notification window and tolerate its later release.
+- Preserve successful skin loading, resize behavior, and capture session use.
+- Add fail-closed source contracts, documentation, and mutation coverage.
+
+## Verification
+
+- focused project and behavior source contracts
+- repository and external-directory `make check`
+- hostile outlet, layer, window, closure, documentation, and plan mutations
+- hosted unsigned macOS build on the exact pull-request head
+- generated-artifact, credential-pattern, and exact-diff audits

--- a/docs/plans/2026-06-14-skin-preview-window-guards.md
+++ b/docs/plans/2026-06-14-skin-preview-window-guards.md
@@ -1,6 +1,6 @@
 # Skin Preview And Window Guards
 
-## Status: Planned
+## Status: Completed
 
 ## Context
 
@@ -29,3 +29,17 @@ not crash the process when optional AppKit state is unavailable.
 - hostile outlet, layer, window, closure, documentation, and plan mutations
 - hosted unsigned macOS build on the exact pull-request head
 - generated-artifact, credential-pattern, and exact-diff audits
+
+## Verification Results
+
+- Focused project and behavior source contracts passed with both preview setup
+  paths guarded and resize notifications using weak lifecycle captures.
+- The repository and external-directory `make check` passed; Linux truthfully
+  used the static-only boundary because `xcodebuild` is unavailable.
+- Seven hostile Skin optional-state mutations were rejected across preview
+  outlet guarding, guarded bounds reuse, local preview-layer construction,
+  resize-window guarding, weak capture, documentation, and completed-plan
+  status.
+- Final generated-artifact, credential-pattern, and exact-diff audits passed
+  with only the intended Skin, checker, documentation, and plan changes.
+- Hosted unsigned macOS compilation remains required on the exact pushed head.

--- a/scripts/check-screenshare-source.py
+++ b/scripts/check-screenshare-source.py
@@ -14,6 +14,7 @@ CI_PLAN = DOCS_PLANS / "2026-06-10-ci-baseline.md"
 DEVICE_SWITCH_ROLLBACK_PLAN = DOCS_PLANS / "2026-06-13-device-switch-rollback.md"
 DEVICE_ARCHIVE_BINDING_PLAN = DOCS_PLANS / "2026-06-13-device-archive-optional-binding.md"
 MAKE_ROOT_PLAN = DOCS_PLANS / "2026-06-14-make-root-override-protection.md"
+SKIN_PREVIEW_WINDOW_PLAN = DOCS_PLANS / "2026-06-14-skin-preview-window-guards.md"
 EXPECTED_WORKFLOW = """name: Check
 
 on:
@@ -108,6 +109,8 @@ def docs_plan_checks():
         errors.append("docs/plans/2026-06-13-device-archive-optional-binding.md is missing")
     if not MAKE_ROOT_PLAN.exists():
         errors.append("docs/plans/2026-06-14-make-root-override-protection.md is missing")
+    if not SKIN_PREVIEW_WINDOW_PLAN.exists():
+        errors.append("docs/plans/2026-06-14-skin-preview-window-guards.md is missing")
 
     plans = sorted(DOCS_PLANS.glob("*.md")) if DOCS_PLANS.exists() else []
     if not plans:
@@ -184,6 +187,10 @@ def project_checks():
             errors.append(f"{doc_path} must document capture device switch rollback")
         if "device archive optional binding" not in document.lower():
             errors.append(f"{doc_path} must document device archive optional binding")
+        if "skin preview and window guards" not in document.lower():
+            errors.append(f"{doc_path} must document Skin preview and window guards")
+    if str(SKIN_PREVIEW_WINDOW_PLAN.relative_to(ROOT)) not in read_text("README.md"):
+        errors.append(f"README.md must reference {SKIN_PREVIEW_WINDOW_PLAN.relative_to(ROOT)}")
 
     project = read_text("Screenshare.xcodeproj/project.pbxproj")
     for fragment in (
@@ -307,6 +314,21 @@ def behavior_checks():
         errors.append("Skin must conditionally cast the application delegate")
     if 'NSLog("ScreenShare application delegate is unavailable.")' not in skin:
         errors.append("Skin must log unavailable application delegate state")
+    if "previewViewLayer!" in skin or "self.videoPreviewLayer!" in skin or "forObject: self.window!" in skin:
+        errors.append("Skin preview and resize setup must not force unwrap optional AppKit state")
+    if skin.count("guard let previewView = self.previewView") != 2 or skin.count("let previewViewLayer = previewView.layer") != 2:
+        errors.append("Skin must guard both preview outlets and backing layers")
+    if skin.count("let videoPreviewLayer = AVCaptureVideoPreviewLayer(session: self.session)") != 2:
+        errors.append("Skin must configure both video preview layers as local nonoptional values")
+    if "originalPreviewViewBounds = previewView.bounds" not in skin:
+        errors.append("Skin must retain preview bounds from the guarded local outlet")
+    if "guard let window = self.window else" not in skin or "[weak self, weak window]" not in skin:
+        errors.append("Skin resize notifications must guard and weakly retain window lifecycle state")
+    if SKIN_PREVIEW_WINDOW_PLAN.exists():
+        plan = SKIN_PREVIEW_WINDOW_PLAN.read_text(encoding="utf-8")
+        for evidence in ("Status: Completed", "repository and external-directory `make check` passed", "hostile Skin optional-state mutations were rejected"):
+            if evidence not in plan:
+                errors.append(f"{SKIN_PREVIEW_WINDOW_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}")
     for fragment in (
         "appDelegate?.selectedDevice = nil",
         "appDelegate?.selectedDevice = self",


### PR DESCRIPTION
## Summary

- Guard both Skin preview outlets and backing layers before configuring capture UI.
- Use local nonoptional preview layers and guarded bounds throughout setup.
- Guard resize-notification window state with weak lifecycle captures.

## Baseline

Skin preview setup could proceed through optional outlets, backing layers, or resize-notification window state without consistently proving that the related UI objects still existed. That left capture setup and resize handling exposed to lifecycle-sensitive failures.

## Improvements

- Guard both Skin preview outlets and their backing layers before configuring capture UI.
- Use local nonoptional preview layers and guarded bounds throughout setup.
- Guard resize-notification window state with weak lifecycle captures.

## Validation

- Repository and external-directory `make check`.
- Seven hostile mutations covering preview outlets, guarded bounds, local layers, resize windows, weak captures, documentation, and plan status.
- Generated-artifact, credential-pattern, staged-diff, and whitespace audits.
- Hosted unsigned macOS build required on the exact PR head.

Local Linux validation truthfully uses the static-only path because `xcodebuild` is unavailable.

## Risk

Interactive ScreenCaptureKit permission, capture, preview, and window-resize behavior cannot be exercised on the Linux validation host. The initial exact-head snapshot had one successful contract check and one pending hosted macOS build, so terminal-green status is not claimed.

## Follow-Ups

Retain the preview-outlet, guarded-bounds, local-layer, resize-window, and weak-capture mutation coverage. Merge this stacked pull request only with explicit authorization and after its base pull request.
