### PR TITLE
fix(capture): guard Skin aspect layout

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-14
 
+- Added Skin aspect layout guards for detached windows, missing screens, and
+  incomplete nib outlets.
 - Added Skin preview and window guards instead of force unwrapping optional
   AppKit outlets and resize-window lifecycle state.
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   to optional-bind outlets, backing layers, input ports, and windows.
 - Skin preview and window guards optional-bind preview layers and resize-window
   lifecycle state instead of force unwrapping AppKit outlets.
+- Skin aspect layout guards tolerate detached windows, missing screens, and
+  incomplete nib outlets during device-dimension updates.
 - Static behavior checks also require session window setup to avoid
   force-unwrapping the main screen or content view.
 - Static behavior checks also require device refreshes to guard the main

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,6 +26,8 @@ Helpful reports include:
 
 Skin preview and window guards must optional-bind AppKit outlets and lifecycle
 state before capture UI setup or resize handling.
+Skin aspect layout guards must tolerate detached windows, missing screens, and
+incomplete nib outlets during device-dimension updates.
 
 - This repository appears to be an Apple platform application or Swift sample. The active security scope is the code and documentation on the default branch.
 - Review found authentication, token, or session-related code paths; changes in those areas should receive security-focused review before merge.

--- a/ScreenShare/Skin.swift
+++ b/ScreenShare/Skin.swift
@@ -126,8 +126,20 @@ class Skin: NSView {
         }
         self.notifications.registerObserver(
             NSWindow.didResizeNotification, forObject: window, dispatchAsyncToMainQueue: true, block: { [weak self, weak window] _ in
-                guard let self = self, let window = window else { return }
-                self.updateViewsToWindow(windowSize: window.frame.size)
+                guard let self = self,
+                      let window = window,
+                      let skinView = self.view,
+                      let deviceFrameImage = self.deviceFrameImage,
+                      let previewView = self.previewView else {
+                    NSLog("Skin resize layout window or outlets are unavailable.")
+                    return
+                }
+                self.updateViewsToWindow(
+                    windowSize: window.frame.size,
+                    window: window,
+                    skinView: skinView,
+                    deviceFrameImage: deviceFrameImage,
+                    previewView: previewView)
         })
     }
     

--- a/ScreenShare/Skin.swift
+++ b/ScreenShare/Skin.swift
@@ -236,34 +236,41 @@ class Skin: NSView {
                 self.device.videDimensions = dimensions
                 self.loadSkinForDevice()
                 
-                if (self.window != nil) {
-                    var windowSize = self.device.getWindowSize() //self.window!.frame.size //self.device.getWindowSize()
-                    windowSize = windowSize.orientation != self.device.orientation ? windowSize.rotated() : windowSize
-                    
-                    if (    self.deviceSettings != nil
-                        &&  !ignoreSettings
-                        &&  self.deviceSettings?.hasPreviousLocation(forOrientation: self.device.orientation) == true ) {
-                            
-                            let windowRect = self.deviceSettings!.savedSettingForOrientation(forOrientation: self.device.orientation)
-                            windowSize =  windowRect.size
-                            positionWindow(windowRect: windowRect)
-                            
-                            
-                    } else {
-                        // Calculate new size to fit screen. -50 is just to give some margins for OS menubar, etc.
-                        var screenFrame = self.window!.screen!.visibleFrame
-                        screenFrame.size.height -= 50
-                        screenFrame.size.width -= 50
-                        windowSize = NSSize(fromCGSize: windowSize).scaleToFit(targetSize: screenFrame.size)
-                        
-                        // Center the window on screen
-                        centerWindow(windowSize: windowSize)
-                    }
-                    
-                    // Resize the internal view to the calculated size / rect
-                    updateViewsToWindow(windowSize: windowSize)
-                    
+                guard let window = self.window,
+                      let skinView = self.view,
+                      let deviceFrameImage = self.deviceFrameImage,
+                      let previewView = self.previewView else {
+                    NSLog("Skin aspect layout window or outlets are unavailable.")
+                    return
                 }
+
+                var windowSize = self.device.getWindowSize()
+                windowSize = windowSize.orientation != self.device.orientation ? windowSize.rotated() : windowSize
+
+                if let deviceSettings = self.deviceSettings,
+                   !ignoreSettings,
+                   deviceSettings.hasPreviousLocation(forOrientation: self.device.orientation) {
+                    let windowRect = deviceSettings.savedSettingForOrientation(forOrientation: self.device.orientation)
+                    windowSize = windowRect.size
+                    positionWindow(windowRect: windowRect, window: window)
+                } else if let screen = window.screen ?? NSScreen.main {
+                    // Leave a small margin for the menu bar and other screen chrome.
+                    var screenFrame = screen.visibleFrame
+                    screenFrame.size.height -= 50
+                    screenFrame.size.width -= 50
+                    windowSize = NSSize(fromCGSize: windowSize).scaleToFit(targetSize: screenFrame.size)
+                    centerWindow(windowSize: windowSize, window: window, screenFrame: screen.frame)
+                } else {
+                    NSLog("Skin aspect layout screen is unavailable.")
+                    window.aspectRatio = windowSize
+                }
+
+                updateViewsToWindow(
+                    windowSize: windowSize,
+                    window: window,
+                    skinView: skinView,
+                    deviceFrameImage: deviceFrameImage,
+                    previewView: previewView)
             }
             return
             
@@ -283,28 +290,29 @@ class Skin: NSView {
         
     }
     
-    func centerWindow(windowSize : NSSize) {
-        self.window!.aspectRatio = windowSize
-        self.window!.setFrame(DeviceUtils.getCenteredRect(windowSize: windowSize, screenFrame: self.window!.screen!.frame), display:true)
+    func centerWindow(windowSize: NSSize, window: NSWindow, screenFrame: NSRect) {
+        window.aspectRatio = windowSize
+        window.setFrame(DeviceUtils.getCenteredRect(windowSize: windowSize, screenFrame: screenFrame), display: true)
         // self.window?.center() does not work
     }
-    func positionWindow(windowRect : NSRect) {
-        self.window!.aspectRatio = windowRect.size
-        self.window!.setFrame(windowRect, display:true)
+    func positionWindow(windowRect: NSRect, window: NSWindow) {
+        window.aspectRatio = windowRect.size
+        window.setFrame(windowRect, display: true)
         // self.window?.center() does not work
     }
     
-    func updateViewsToWindow(windowSize : NSSize) {
+    func updateViewsToWindow(windowSize: NSSize, window: NSWindow, skinView: NSView,
+                             deviceFrameImage: NSImageView, previewView: NSView) {
         
         self.setFrameSize(windowSize)
         self.setFrameOrigin(NSPoint(x: 0,y: 0))
-        self.view.frame = self.bounds
+        skinView.frame = self.bounds
         
-        self.deviceFrameImage.image = NSImage(named: self.device.getSkinDeviceImage())
-        self.deviceFrameImage.translatesAutoresizingMaskIntoConstraints = true
-        self.deviceFrameImage.setFrameSize(self.bounds.size)
-        self.deviceFrameImage.setFrameOrigin(NSPoint(x: 0,y: 0))
-        self.deviceFrameImage.needsDisplay = true
+        deviceFrameImage.image = NSImage(named: self.device.getSkinDeviceImage())
+        deviceFrameImage.translatesAutoresizingMaskIntoConstraints = true
+        deviceFrameImage.setFrameSize(self.bounds.size)
+        deviceFrameImage.setFrameOrigin(NSPoint(x: 0,y: 0))
+        deviceFrameImage.needsDisplay = true
         
         let scale  = windowSize.width / ( self.device.orientation == .Portrait ? self.device.skinSize.width : self.device.skinSize.height )
         var size = NSSize(width: originalPreviewViewBounds.size.width * scale, height: originalPreviewViewBounds.size.height * scale)
@@ -312,19 +320,19 @@ class Skin: NSView {
             size = size.rotated()
         }
         
-        self.previewView.translatesAutoresizingMaskIntoConstraints = true
-        self.previewView.setFrameSize(size)
+        previewView.translatesAutoresizingMaskIntoConstraints = true
+        previewView.setFrameSize(size)
         
         let origin = NSPoint(
             x: windowSize.width / 2 - size.width / 2,
             y: windowSize.height / 2 - size.height / 2)
         
-        self.previewView.setFrameOrigin(origin)
+        previewView.setFrameOrigin(origin)
         
-        self.videoPreviewLayer?.frame = self.previewView.bounds
+        self.videoPreviewLayer?.frame = previewView.bounds
         
         self.needsDisplay = true
-        self.window!.invalidateShadow()
+        window.invalidateShadow()
         
         if trackingArea != nil {
             self.removeTrackingArea(trackingArea!)

--- a/VISION.md
+++ b/VISION.md
@@ -28,6 +28,7 @@ Priority:
 - Keep preview aspect updates responsive to width and height changes
 - Keep document preview and aspect setup tolerant of missing nib or capture state
 - Keep Skin preview and window guards across AppKit lifecycle gaps
+- Keep Skin aspect layout guards around window, screen, and nib outlet state
 - Release repeating preview timers when document windows close
 - Keep session window setup tolerant of missing screen or content-view state
 - Keep device refreshes tolerant of missing main window outlet state

--- a/docs/plans/2026-06-14-skin-aspect-layout-guards.md
+++ b/docs/plans/2026-06-14-skin-aspect-layout-guards.md
@@ -1,0 +1,55 @@
+# Skin Aspect Layout Guards
+
+## Status: Planned
+
+## Context
+
+Skin preview creation and resize-notification registration now guard optional
+AppKit state. The later aspect-layout path still force unwraps the owning window,
+its screen, and nib-backed view outlets, so device-dimension updates can crash
+when a window is detached or skin loading is incomplete.
+
+## Priority
+
+High capture UI reliability. Aspect recalculation runs during device setup and
+format changes and must fail closed at AppKit lifecycle boundaries.
+
+## Requirements
+
+- Guard the owning window before aspect layout and pass that nonoptional value
+  through layout helpers.
+- Tolerate a missing window screen without force unwrapping or crashing.
+- Guard the skin view, device frame image, and preview view before resizing.
+- Preserve saved device positioning, scale-to-fit behavior, centering, shadow
+  invalidation, and successful capture preview layout.
+- Add fail-closed source contracts and keep maintained documentation and
+  completed verification evidence aligned.
+
+## Scope Boundaries
+
+- Do not change mouse interaction, capture-device switching, archive settings,
+  session policy, nib contents, or supported macOS/Xcode versions.
+
+## Implementation Units
+
+1. Bind the aspect-layout window once and use an optional screen frame for
+   scaling and centering.
+2. Pass guarded window state into positioning and view-layout helpers and bind
+   required nib outlets before mutation.
+3. Extend source contracts and maintained documentation for the layout boundary
+   and completed validation evidence.
+
+## Verification
+
+- focused project and behavior source contracts
+- repository and external-directory `make check`
+- hostile window, screen, outlet, helper, documentation, and plan mutations
+- hosted unsigned macOS build on the exact pull-request head
+- generated-artifact, credential-pattern, and exact-diff audits
+
+## Risks
+
+- Linux validation is static-only; AppKit API compatibility requires the hosted
+  macOS/Xcode build.
+- Nib loading, physical-device mirroring, and live window movement still require
+  manual macOS hardware validation.

--- a/docs/plans/2026-06-14-skin-aspect-layout-guards.md
+++ b/docs/plans/2026-06-14-skin-aspect-layout-guards.md
@@ -20,6 +20,8 @@ format changes and must fail closed at AppKit lifecycle boundaries.
   through layout helpers.
 - Tolerate a missing window screen without force unwrapping or crashing.
 - Guard the skin view, device frame image, and preview view before resizing.
+- Keep the resize-notification callback aligned with the guarded
+  `updateViewsToWindow` helper contract.
 - Preserve saved device positioning, scale-to-fit behavior, centering, shadow
   invalidation, and successful capture preview layout.
 - Add fail-closed source contracts and keep maintained documentation and
@@ -56,9 +58,15 @@ format changes and must fail closed at AppKit lifecycle boundaries.
 - Six hostile Skin aspect-layout mutations were rejected across window binding,
   screen fallback, outlet binding, helper handoff, documentation, and completed
   plan status.
+- The initial exact-head hosted build exposed a stale resize callback that still
+  called `updateViewsToWindow` with only the window size. The callback now binds
+  the required outlets and forwards every nonoptional helper argument.
+- Focused contracts, repository and external-directory `make check`, and six
+  isolated resize-callback mutations passed after the hosted compile fix.
 - Final generated-artifact, credential-pattern, and exact-diff audits passed
   with only the intended Skin, checker, documentation, and plan changes.
-- Hosted unsigned macOS compilation remains required on the exact pushed head.
+- Hosted unsigned macOS compilation remains required on the corrected pushed
+  head.
 
 ## Risks
 

--- a/docs/plans/2026-06-14-skin-aspect-layout-guards.md
+++ b/docs/plans/2026-06-14-skin-aspect-layout-guards.md
@@ -1,6 +1,6 @@
 # Skin Aspect Layout Guards
 
-## Status: Planned
+## Status: Completed
 
 ## Context
 
@@ -46,6 +46,19 @@ format changes and must fail closed at AppKit lifecycle boundaries.
 - hostile window, screen, outlet, helper, documentation, and plan mutations
 - hosted unsigned macOS build on the exact pull-request head
 - generated-artifact, credential-pattern, and exact-diff audits
+
+## Verification Results
+
+- Focused project and behavior source contracts passed with one guarded window
+  and outlet binding, optional screen fallback, and nonoptional helper inputs.
+- The repository and external-directory `make check` passed; Linux truthfully
+  used the static-only boundary because `xcodebuild` is unavailable.
+- Six hostile Skin aspect-layout mutations were rejected across window binding,
+  screen fallback, outlet binding, helper handoff, documentation, and completed
+  plan status.
+- Final generated-artifact, credential-pattern, and exact-diff audits passed
+  with only the intended Skin, checker, documentation, and plan changes.
+- Hosted unsigned macOS compilation remains required on the exact pushed head.
 
 ## Risks
 

--- a/scripts/check-screenshare-source.py
+++ b/scripts/check-screenshare-source.py
@@ -329,6 +329,21 @@ def behavior_checks():
         errors.append("Skin must retain preview bounds from the guarded local outlet")
     if "guard let window = self.window else" not in skin or "[weak self, weak window]" not in skin:
         errors.append("Skin resize notifications must guard and weakly retain window lifecycle state")
+    resize_start = skin.find("func registerNotifications()")
+    resize_end = skin.find("func initWithDevice(device: AVCaptureDevice)")
+    resize_layout = skin[resize_start:resize_end]
+    for fragment in (
+        "let skinView = self.view,",
+        "let deviceFrameImage = self.deviceFrameImage,",
+        "let previewView = self.previewView else",
+        "windowSize: window.frame.size,",
+        "window: window,",
+        "skinView: skinView,",
+        "deviceFrameImage: deviceFrameImage,",
+        "previewView: previewView)",
+    ):
+        if resize_start < 0 or resize_end < 0 or fragment not in resize_layout:
+            errors.append(f"Skin resize layout must retain guarded state via {fragment!r}")
     if SKIN_PREVIEW_WINDOW_PLAN.exists():
         plan = SKIN_PREVIEW_WINDOW_PLAN.read_text(encoding="utf-8")
         for evidence in ("Status: Completed", "repository and external-directory `make check` passed", "hostile Skin optional-state mutations were rejected"):

--- a/scripts/check-screenshare-source.py
+++ b/scripts/check-screenshare-source.py
@@ -15,6 +15,7 @@ DEVICE_SWITCH_ROLLBACK_PLAN = DOCS_PLANS / "2026-06-13-device-switch-rollback.md
 DEVICE_ARCHIVE_BINDING_PLAN = DOCS_PLANS / "2026-06-13-device-archive-optional-binding.md"
 MAKE_ROOT_PLAN = DOCS_PLANS / "2026-06-14-make-root-override-protection.md"
 SKIN_PREVIEW_WINDOW_PLAN = DOCS_PLANS / "2026-06-14-skin-preview-window-guards.md"
+SKIN_ASPECT_LAYOUT_PLAN = DOCS_PLANS / "2026-06-14-skin-aspect-layout-guards.md"
 EXPECTED_WORKFLOW = """name: Check
 
 on:
@@ -111,6 +112,8 @@ def docs_plan_checks():
         errors.append("docs/plans/2026-06-14-make-root-override-protection.md is missing")
     if not SKIN_PREVIEW_WINDOW_PLAN.exists():
         errors.append("docs/plans/2026-06-14-skin-preview-window-guards.md is missing")
+    if not SKIN_ASPECT_LAYOUT_PLAN.exists():
+        errors.append("docs/plans/2026-06-14-skin-aspect-layout-guards.md is missing")
 
     plans = sorted(DOCS_PLANS.glob("*.md")) if DOCS_PLANS.exists() else []
     if not plans:
@@ -189,6 +192,8 @@ def project_checks():
             errors.append(f"{doc_path} must document device archive optional binding")
         if "skin preview and window guards" not in document.lower():
             errors.append(f"{doc_path} must document Skin preview and window guards")
+        if "skin aspect layout guards" not in document.lower():
+            errors.append(f"{doc_path} must document Skin aspect layout guards")
     if str(SKIN_PREVIEW_WINDOW_PLAN.relative_to(ROOT)) not in read_text("README.md"):
         errors.append(f"README.md must reference {SKIN_PREVIEW_WINDOW_PLAN.relative_to(ROOT)}")
 
@@ -329,6 +334,32 @@ def behavior_checks():
         for evidence in ("Status: Completed", "repository and external-directory `make check` passed", "hostile Skin optional-state mutations were rejected"):
             if evidence not in plan:
                 errors.append(f"{SKIN_PREVIEW_WINDOW_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}")
+    for fragment in (
+        "guard let window = self.window,",
+        "let skinView = self.view,",
+        "let deviceFrameImage = self.deviceFrameImage,",
+        "let previewView = self.previewView else",
+        "let screen = window.screen ?? NSScreen.main",
+        "var screenFrame = screen.visibleFrame",
+        "positionWindow(windowRect: windowRect, window: window)",
+        "centerWindow(windowSize: windowSize, window: window, screenFrame: screen.frame)",
+        "func centerWindow(windowSize: NSSize, window: NSWindow, screenFrame: NSRect)",
+        "func positionWindow(windowRect: NSRect, window: NSWindow)",
+        "func updateViewsToWindow(windowSize: NSSize, window: NSWindow, skinView: NSView,",
+        "window.invalidateShadow()",
+    ):
+        if fragment not in skin:
+            errors.append(f"Skin aspect layout must retain guarded state via {fragment!r}")
+    aspect_start = skin.find("func updateAspect(ignoreSettings:Bool)")
+    aspect_end = skin.find("func scaleToFit(forgetSettings:Bool)")
+    aspect_layout = skin[aspect_start:aspect_end]
+    if aspect_start < 0 or aspect_end < 0 or "self.window!" in aspect_layout or "self.deviceSettings!" in aspect_layout:
+        errors.append("Skin aspect layout must not force unwrap window or device settings state")
+    if SKIN_ASPECT_LAYOUT_PLAN.exists():
+        plan = SKIN_ASPECT_LAYOUT_PLAN.read_text(encoding="utf-8")
+        for evidence in ("Status: Completed", "repository and external-directory `make check` passed", "hostile Skin aspect-layout mutations were rejected"):
+            if evidence not in plan:
+                errors.append(f"{SKIN_ASPECT_LAYOUT_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}")
     for fragment in (
         "appDelegate?.selectedDevice = nil",
         "appDelegate?.selectedDevice = self",


### PR DESCRIPTION
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)

## Summary

Device aspect updates no longer crash when the Skin window is detached, its screen is unavailable, or nib-backed layout outlets are incomplete. Successful layouts retain saved positioning, scale-to-fit behavior, full-screen centering, preview resizing, and shadow refresh.

## Baseline

Preview creation and resize notifications already guarded optional AppKit state, but the later aspect-layout path still force unwrapped the window, screen, saved settings, and view outlets during device format changes. The first hosted build also exposed a stale resize callback that no longer matched the expanded view-layout helper signature.

## Improvements

- Bind the aspect-layout window and required nib outlets once before any layout mutation.
- Use the attached screen or main-screen fallback for scaling and centering, while failing closed when neither exists.
- Pass nonoptional window and view state through positioning and resizing helpers.
- Keep the resize-notification callback aligned with the guarded helper contract.
- Preserve visible-frame scaling and full-frame centering semantics from the original implementation.
- Add fail-closed source contracts and completed maintenance evidence.

## Validation

- Repository and external-directory `make check` passed project and behavior contracts.
- Six original aspect-layout mutations and six isolated resize-callback mutations were rejected.
- The initial exact-head hosted build identified the missing callback arguments; commit `ec75108` fixes that compiler failure without weakening the contract or build job.
- Exact diff, whitespace, generated-artifact, and changed-line secret audits passed for the three intended follow-up paths.
- Browser validation is not applicable to this native macOS AppKit path.
- Linux does not provide `xcodebuild`; the corrected exact-head hosted unsigned macOS build remains authoritative.

## Risk

The change is limited to aspect layout and callback handoff. Nib loading, physical-device mirroring, live window movement, and AppKit lifecycle timing still require manual macOS hardware validation.

## Follow-Ups

This PR is stacked on PR #13 and must remain open until explicitly integrated or retargeted. On the first maintainer-owned macOS smoke test after integration, resize a mirrored device while detaching and restoring window or screen state; a crash, lost saved position, or malformed preview geometry is the rollback trigger. Mouse drag and resize interaction force unwraps remain outside this change and should be reviewed separately.
