### PR TITLE
Guard Skin pointer lifecycle state

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-15
+
+- Added Skin pointer and window guards for movement and device-settings
+  persistence when AppKit state is unavailable.
+
 ## 2026-06-14
 
 - Added Skin aspect layout guards for detached windows, missing screens, and

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   lifecycle state instead of force unwrapping AppKit outlets.
 - Skin aspect layout guards tolerate detached windows, missing screens, and
   incomplete nib outlets during device-dimension updates.
+- Skin pointer and window guards keep drag and settings callbacks from
+  force-unwrapping AppKit state during teardown.
 - Static behavior checks also require session window setup to avoid
   force-unwrapping the main screen or content view.
 - Static behavior checks also require device refreshes to guard the main

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,6 +28,8 @@ Skin preview and window guards must optional-bind AppKit outlets and lifecycle
 state before capture UI setup or resize handling.
 Skin aspect layout guards must tolerate detached windows, missing screens, and
 incomplete nib outlets during device-dimension updates.
+Skin pointer and window guards must fail closed when drag or settings callbacks
+outlive their window, outlet, pointer-origin, screen, or saved-settings state.
 
 - This repository appears to be an Apple platform application or Swift sample. The active security scope is the code and documentation on the default branch.
 - Review found authentication, token, or session-related code paths; changes in those areas should receive security-focused review before merge.

--- a/ScreenShare/Skin.swift
+++ b/ScreenShare/Skin.swift
@@ -415,34 +415,45 @@ class Skin: NSView {
         self.window?.invalidateShadow()
     }
     override func mouseDown(with theEvent: NSEvent) {
-        initialLocation = NSEvent.mouseLocation
-        
-        initialLocation?.x -= self.window!.frame.origin.x
-        initialLocation?.y -= self.window!.frame.origin.y
-        
-        isResize = (initialLocation!.x > self.deviceFrameImage!.bounds.size.width - ResizeHandleSize)
-            && (initialLocation!.y < ResizeHandleSize)
+        guard let window = self.window,
+              let deviceFrameImage = self.deviceFrameImage else {
+            NSLog("Skin pointer window or preview outlet is unavailable.")
+            initialLocation = nil
+            isResize = false
+            return
+        }
+
+        var pointerLocation = NSEvent.mouseLocation
+        pointerLocation.x -= window.frame.origin.x
+        pointerLocation.y -= window.frame.origin.y
+        initialLocation = pointerLocation
+
+        isResize = (pointerLocation.x > deviceFrameImage.bounds.size.width - ResizeHandleSize)
+            && (pointerLocation.y < ResizeHandleSize)
         
         appDelegate?.selectedDevice = self
         
     }
     
     override func mouseDragged(with theEvent: NSEvent) {
-        
+        guard let initialLocation = initialLocation,
+              let window = self.window else {
+            NSLog("Skin drag window or pointer origin is unavailable.")
+            return
+        }
+
         if !isResize {
-            
             let curLocation = NSEvent.mouseLocation
-            
             var newOrigin = NSPoint(
-                x: curLocation.x - initialLocation!.x,
-                y: curLocation.y - initialLocation!.y)
-            
-            let screenFrame = NSScreen.main?.frame
-            if((newOrigin.y + window!.frame.size.height) > (screenFrame!.origin.y + screenFrame!.size.height)) {
-                newOrigin.y = screenFrame!.origin.y + (screenFrame!.size.height - window!.frame.size.height)
+                x: curLocation.x - initialLocation.x,
+                y: curLocation.y - initialLocation.y)
+
+            if let screenFrame = (window.screen ?? NSScreen.main)?.frame,
+               (newOrigin.y + window.frame.size.height) > (screenFrame.origin.y + screenFrame.size.height) {
+                newOrigin.y = screenFrame.origin.y + (screenFrame.size.height - window.frame.size.height)
             }
-            
-            self.window!.setFrameOrigin(newOrigin)
+
+            window.setFrameOrigin(newOrigin)
         }
         updateDeviceSettings()
         
@@ -454,12 +465,15 @@ class Skin: NSView {
     //MARK: Device Settings
     func updateDeviceSettings() {
         // Update current device size/location settings based on its current movement
-        if(self.deviceSettings != nil) {
-            if self.device.orientation == Device.DeviceOrientation.Portrait {
-                self.deviceSettings!.portraitRect = window!.frame
-            } else {
-                self.deviceSettings!.landscapeRect = window!.frame
-            }
+        guard let deviceSettings = self.deviceSettings,
+              let window = self.window else {
+            NSLog("Skin device settings window or state is unavailable.")
+            return
+        }
+        if self.device.orientation == Device.DeviceOrientation.Portrait {
+            deviceSettings.portraitRect = window.frame
+        } else {
+            deviceSettings.landscapeRect = window.frame
         }
         saveDeviceSettins()
         

--- a/VISION.md
+++ b/VISION.md
@@ -29,6 +29,7 @@ Priority:
 - Keep document preview and aspect setup tolerant of missing nib or capture state
 - Keep Skin preview and window guards across AppKit lifecycle gaps
 - Keep Skin aspect layout guards around window, screen, and nib outlet state
+- Keep Skin pointer and window guards around drag and settings persistence callbacks
 - Release repeating preview timers when document windows close
 - Keep session window setup tolerant of missing screen or content-view state
 - Keep device refreshes tolerant of missing main window outlet state

--- a/docs/plans/2026-06-15-skin-pointer-window-guards.md
+++ b/docs/plans/2026-06-15-skin-pointer-window-guards.md
@@ -1,6 +1,6 @@
 # Skin Pointer and Window Guards
 
-## Status: In Progress
+## Status: Completed
 
 ## Context
 
@@ -49,3 +49,21 @@ instead of crashing when AppKit state disappears.
   completed-plan mutations
 - shell syntax, workflow YAML, plist, scheme XML, generated-artifact,
   credential-pattern, and exact-diff audits
+
+## Verification Results
+
+- Focused project and behavior source-contract validation passed.
+- The repository and external-directory `make check` passed; Linux truthfully
+  used the documented static-only path because `xcodebuild` is unavailable.
+- Six hostile Skin pointer mutations were rejected across pointer-window,
+  pointer-origin, screen, settings, documentation, and completed-plan state.
+- Shell syntax, workflow YAML, Info and entitlements plists, shared scheme XML,
+  generated-artifact, credential-pattern, conflict-marker, and exact-diff
+  audits passed.
+
+## Remaining Risks
+
+- Connected-device capture, interactive dragging, and live resize behavior still
+  require manual validation on macOS with available capture hardware.
+- Hosted unsigned compilation proves source compatibility but does not exercise
+  AppKit teardown timing or pointer callbacks.

--- a/docs/plans/2026-06-15-skin-pointer-window-guards.md
+++ b/docs/plans/2026-06-15-skin-pointer-window-guards.md
@@ -1,0 +1,51 @@
+# Skin Pointer and Window Guards
+
+## Status: In Progress
+
+## Context
+
+The Skin preview and aspect-layout paths now guard optional AppKit state, but
+mouse movement and device-settings persistence still force-unwrap the window,
+preview image outlet, stored pointer origin, main screen, and device settings.
+Those callbacks can outlive outlet or window availability during teardown.
+
+## Priority
+
+High UI lifecycle resilience. Pointer and resize callbacks should fail closed
+instead of crashing when AppKit state disappears.
+
+## Requirements
+
+- Guard the mouse-down window and preview-image outlet before calculating resize
+  state.
+- Guard the stored pointer origin and window during drag callbacks.
+- Clamp movement only when a window or main screen frame is available.
+- Guard window and device settings before persisting orientation-specific frames.
+- Preserve capture, aspect layout, resize behavior, device switching, and archive
+  format.
+- Add fail-closed static and mutation-sensitive contracts.
+
+## Scope Boundaries
+
+- Do not change capture session setup, device archive encoding, project files,
+  dependencies, or window aspect calculations.
+- Do not claim connected-device or interactive pointer validation from Linux or
+  unsigned hosted builds.
+- Do not merge or close stacked pull requests without explicit authorization.
+
+## Implementation Units
+
+1. Replace pointer-handler force unwraps with guarded local window, outlet,
+   pointer-origin, and optional screen values.
+2. Guard device-settings persistence with local nonoptional settings and window
+   values.
+3. Extend source contracts, maintained documentation, and completed evidence.
+
+## Verification
+
+- focused project and behavior source-contract validation
+- repository and external-directory `make check`
+- hostile pointer-window, pointer-origin, screen, settings, documentation, and
+  completed-plan mutations
+- shell syntax, workflow YAML, plist, scheme XML, generated-artifact,
+  credential-pattern, and exact-diff audits

--- a/scripts/check-screenshare-source.py
+++ b/scripts/check-screenshare-source.py
@@ -16,6 +16,7 @@ DEVICE_ARCHIVE_BINDING_PLAN = DOCS_PLANS / "2026-06-13-device-archive-optional-b
 MAKE_ROOT_PLAN = DOCS_PLANS / "2026-06-14-make-root-override-protection.md"
 SKIN_PREVIEW_WINDOW_PLAN = DOCS_PLANS / "2026-06-14-skin-preview-window-guards.md"
 SKIN_ASPECT_LAYOUT_PLAN = DOCS_PLANS / "2026-06-14-skin-aspect-layout-guards.md"
+SKIN_POINTER_WINDOW_PLAN = DOCS_PLANS / "2026-06-15-skin-pointer-window-guards.md"
 EXPECTED_WORKFLOW = """name: Check
 
 on:
@@ -114,6 +115,8 @@ def docs_plan_checks():
         errors.append("docs/plans/2026-06-14-skin-preview-window-guards.md is missing")
     if not SKIN_ASPECT_LAYOUT_PLAN.exists():
         errors.append("docs/plans/2026-06-14-skin-aspect-layout-guards.md is missing")
+    if not SKIN_POINTER_WINDOW_PLAN.exists():
+        errors.append("docs/plans/2026-06-15-skin-pointer-window-guards.md is missing")
 
     plans = sorted(DOCS_PLANS.glob("*.md")) if DOCS_PLANS.exists() else []
     if not plans:
@@ -194,6 +197,8 @@ def project_checks():
             errors.append(f"{doc_path} must document Skin preview and window guards")
         if "skin aspect layout guards" not in document.lower():
             errors.append(f"{doc_path} must document Skin aspect layout guards")
+        if "skin pointer and window guards" not in document.lower():
+            errors.append(f"{doc_path} must document Skin pointer and window guards")
     if str(SKIN_PREVIEW_WINDOW_PLAN.relative_to(ROOT)) not in read_text("README.md"):
         errors.append(f"README.md must reference {SKIN_PREVIEW_WINDOW_PLAN.relative_to(ROOT)}")
 
@@ -375,6 +380,41 @@ def behavior_checks():
         for evidence in ("Status: Completed", "repository and external-directory `make check` passed", "hostile Skin aspect-layout mutations were rejected"):
             if evidence not in plan:
                 errors.append(f"{SKIN_ASPECT_LAYOUT_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}")
+    pointer_start = skin.find("override func mouseDown(with theEvent: NSEvent)")
+    pointer_end = skin.find("override func viewDidEndLiveResize()")
+    pointer_handlers = skin[pointer_start:pointer_end]
+    for fragment in (
+        "guard let window = self.window,",
+        "let deviceFrameImage = self.deviceFrameImage else",
+        "var pointerLocation = NSEvent.mouseLocation",
+        "guard let initialLocation = initialLocation,",
+        "let window = self.window else",
+        "if let screenFrame = (window.screen ?? NSScreen.main)?.frame",
+        "window.setFrameOrigin(newOrigin)",
+    ):
+        if pointer_start < 0 or pointer_end < 0 or fragment not in pointer_handlers:
+            errors.append(f"Skin pointer handlers must retain guarded state via {fragment!r}")
+    for unsafe_fragment in ("self.window!", "initialLocation!", "deviceFrameImage!", "screenFrame!"):
+        if unsafe_fragment in pointer_handlers:
+            errors.append(f"Skin pointer handlers must not force unwrap optional state via {unsafe_fragment!r}")
+    settings_start = skin.find("func updateDeviceSettings()")
+    settings_end = skin.find("func getDeviceSettings(device: AVCaptureDevice)")
+    settings_update = skin[settings_start:settings_end]
+    for fragment in (
+        "guard let deviceSettings = self.deviceSettings,",
+        "let window = self.window else",
+        "deviceSettings.portraitRect = window.frame",
+        "deviceSettings.landscapeRect = window.frame",
+    ):
+        if settings_start < 0 or settings_end < 0 or fragment not in settings_update:
+            errors.append(f"Skin device settings persistence must retain guarded state via {fragment!r}")
+    if "self.deviceSettings!" in settings_update or "window!" in settings_update:
+        errors.append("Skin device settings persistence must not force unwrap optional state")
+    if SKIN_POINTER_WINDOW_PLAN.exists():
+        plan = SKIN_POINTER_WINDOW_PLAN.read_text(encoding="utf-8")
+        for evidence in ("Status: Completed", "repository and external-directory `make check` passed", "hostile Skin pointer mutations were rejected"):
+            if evidence not in plan:
+                errors.append(f"{SKIN_POINTER_WINDOW_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}")
     for fragment in (
         "appDelegate?.selectedDevice = nil",
         "appDelegate?.selectedDevice = self",


### PR DESCRIPTION
## Summary

Guard Skin pointer movement and device-settings persistence when AppKit window, outlet, pointer-origin, screen, or saved-settings state is unavailable.

## Baseline

PR #14 guards preview and aspect-layout callbacks, but `mouseDown`, `mouseDragged`, and `updateDeviceSettings` still force-unwrapped adjacent optional lifecycle state.

## Improvements

- Guard the mouse-down window and preview image before calculating resize state.
- Guard the stored pointer origin and window during drag callbacks.
- Clamp movement only when the window or main screen frame is available.
- Persist orientation frames only with local nonoptional settings and window values.
- Add fail-closed method-slice, documentation, and completed-plan contracts.

## Validation

- Repository and external-directory `make check` passed project and behavior contracts.
- Six focused hostile pointer-window, force-unwrap, screen, settings, documentation, and plan mutations were rejected.
- Shell syntax, workflow YAML, Info and entitlements plists, shared scheme XML, generated-artifact, credential, conflict-marker, and exact-diff audits passed.
- Local Linux validation truthfully remained static-only because `xcodebuild` is unavailable.

## Risk

Connected-device capture, interactive dragging, and live resize behavior still require manual macOS validation. Hosted unsigned compilation verifies source compatibility but does not exercise AppKit teardown timing.

## Follow-Ups

This PR is stacked on PR #14 and should retain base-first ordering. Do not merge or close either PR without explicit owner authorization.
