### PR TITLE
Guard device session registration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-15
 
+- Made device-session creation failable so a missing window content view cannot
+  leave a detached capture skin registered as an active session.
 - Added Skin pointer and window guards for movement and device-settings
   persistence when AppKit state is unavailable.
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   force-unwrapping AppKit state during teardown.
 - Static behavior checks also require session window setup to avoid
   force-unwrapping the main screen or content view.
+- Session registration guards require window attachment to succeed before a
+  capture skin is started or recorded as an active device session.
 - Static behavior checks also require device refreshes to guard the main
   device-list window before hiding or showing it.
 - Static behavior checks also require document aspect timers to be replaced and

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,6 +30,8 @@ Skin aspect layout guards must tolerate detached windows, missing screens, and
 incomplete nib outlets during device-dimension updates.
 Skin pointer and window guards must fail closed when drag or settings callbacks
 outlive their window, outlet, pointer-origin, screen, or saved-settings state.
+Session registration guards must fail before capture starts when a new window
+cannot host its capture skin.
 
 - This repository appears to be an Apple platform application or Swift sample. The active security scope is the code and documentation on the default branch.
 - Review found authentication, token, or session-related code paths; changes in those areas should receive security-focused review before merge.

--- a/ScreenShare/AppDelegate.swift
+++ b/ScreenShare/AppDelegate.swift
@@ -104,7 +104,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         
     }
     
-    func startNewSession(device:AVCaptureDevice) -> Skin {
+    func startNewSession(device:AVCaptureDevice) -> Skin? {
         
         let size = DeviceUtils(deviceType: .Phone).skinSize
         let screenFrame = NSScreen.main?.frame ?? NSMakeRect(0, 0, size.width, size.height)
@@ -113,6 +113,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         let window = NSWindow(contentRect: frame,
             styleMask: .borderless,
             backing: .buffered, defer: false)
+
+        guard let contentView = window.contentView else {
+            NSLog("Device session window content view is missing.")
+            return nil
+        }
         
         window.isMovableByWindowBackground = true
         let frameView = NSMakeRect(0, 0,size.width, size.height)
@@ -120,10 +125,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         let skin = Skin(frame: frameView)
         skin.initWithDevice(device: device)
         skin.ownerWindow = window
-        guard let contentView = window.contentView else {
-            NSLog("Device session window content view is missing.")
-            return skin
-        }
         contentView.addSubview(skin)
         
         skin.registerNotifications()
@@ -167,7 +168,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
                         break;
                     } else {
-                        self.deviceSessions[device] = startNewSession(device: device)
+                        if let skin = startNewSession(device: device) {
+                            self.deviceSessions[device] = skin
+                        }
                     }
             }
         }

--- a/VISION.md
+++ b/VISION.md
@@ -32,6 +32,7 @@ Priority:
 - Keep Skin pointer and window guards around drag and settings persistence callbacks
 - Release repeating preview timers when document windows close
 - Keep session window setup tolerant of missing screen or content-view state
+- Register device sessions only after their capture skin can attach to a window
 - Keep device refreshes tolerant of missing main window outlet state
 - Keep capture skins tolerant of unavailable application delegate state
 - Maintain custom skin and screenshot context

--- a/docs/plans/2026-06-15-session-registration-guard.md
+++ b/docs/plans/2026-06-15-session-registration-guard.md
@@ -1,0 +1,55 @@
+# Session Registration Guard
+
+## Status: Planned
+
+## Context
+
+`AppDelegate.startNewSession` currently returns a `Skin` when the newly created
+window has no content view. `refreshDevices` then records that detached skin as
+an active device session even though it was never attached, registered, or
+shown. The phantom entry blocks a later retry and leaves its capture session
+running.
+
+## Priority
+
+High capture lifecycle resilience. A device session should become visible to
+the session registry only after its window can host the capture view.
+
+## Requirements
+
+- Make device-session creation explicitly failable.
+- Guard the window content view before constructing or starting the capture
+  skin.
+- Register a device session only after creation and attachment succeed.
+- Preserve the single-device policy, capture setup, and window presentation.
+- Add mutation-sensitive static contracts for failure ordering and conditional
+  registration.
+
+## Scope Boundaries
+
+- Do not change capture input selection, archive encoding, project files,
+  dependencies, or window layout calculations.
+- Do not claim connected-device validation from Linux or unsigned hosted builds.
+- Do not merge or close stacked pull requests without explicit authorization.
+
+## Implementation Units
+
+1. Return an optional skin from `startNewSession` and fail before skin creation
+   when the window cannot provide a content view.
+2. Store the new session only through optional binding in `refreshDevices`.
+3. Extend source contracts and maintained documentation, then record completed
+   verification evidence.
+
+## Verification
+
+- focused project and behavior source-contract validation
+- repository and external-directory `make check`
+- hostile return-type, guard-order, failure-return, and unconditional-registry
+  mutations
+- shell syntax, workflow YAML, plist, scheme XML, generated-artifact,
+  credential-pattern, and exact-diff audits
+
+## Remaining Risks
+
+- Connected-device capture and unusual AppKit window construction states still
+  require manual validation on macOS with capture hardware.

--- a/docs/plans/2026-06-15-session-registration-guard.md
+++ b/docs/plans/2026-06-15-session-registration-guard.md
@@ -1,6 +1,6 @@
 # Session Registration Guard
 
-## Status: Planned
+## Status: Completed
 
 ## Context
 
@@ -48,6 +48,18 @@ the session registry only after its window can host the capture view.
   mutations
 - shell syntax, workflow YAML, plist, scheme XML, generated-artifact,
   credential-pattern, and exact-diff audits
+
+## Verification Results
+
+- Focused project and behavior source-contract validation passed.
+- The repository and external-directory `make check` passed; Linux truthfully
+  used the documented static-only path because `xcodebuild` is unavailable.
+- Four hostile session-registration mutations were rejected across optional
+  return type, guard ordering, nil failure return, and conditional registry
+  state.
+- Shell syntax, workflow YAML, Info and entitlements plists, shared scheme XML,
+  generated-artifact, credential-pattern, conflict-marker, and exact-diff
+  audits passed.
 
 ## Remaining Risks
 

--- a/scripts/check-screenshare-source.py
+++ b/scripts/check-screenshare-source.py
@@ -17,6 +17,7 @@ MAKE_ROOT_PLAN = DOCS_PLANS / "2026-06-14-make-root-override-protection.md"
 SKIN_PREVIEW_WINDOW_PLAN = DOCS_PLANS / "2026-06-14-skin-preview-window-guards.md"
 SKIN_ASPECT_LAYOUT_PLAN = DOCS_PLANS / "2026-06-14-skin-aspect-layout-guards.md"
 SKIN_POINTER_WINDOW_PLAN = DOCS_PLANS / "2026-06-15-skin-pointer-window-guards.md"
+SESSION_REGISTRATION_PLAN = DOCS_PLANS / "2026-06-15-session-registration-guard.md"
 EXPECTED_WORKFLOW = """name: Check
 
 on:
@@ -117,6 +118,8 @@ def docs_plan_checks():
         errors.append("docs/plans/2026-06-14-skin-aspect-layout-guards.md is missing")
     if not SKIN_POINTER_WINDOW_PLAN.exists():
         errors.append("docs/plans/2026-06-15-skin-pointer-window-guards.md is missing")
+    if not SESSION_REGISTRATION_PLAN.exists():
+        errors.append("docs/plans/2026-06-15-session-registration-guard.md is missing")
 
     plans = sorted(DOCS_PLANS.glob("*.md")) if DOCS_PLANS.exists() else []
     if not plans:
@@ -431,6 +434,31 @@ def behavior_checks():
         errors.append("AppDelegate.startNewSession must not force unwrap the session window content view")
     if "guard let contentView = window.contentView else" not in app_delegate or "contentView.addSubview(skin)" not in app_delegate:
         errors.append("AppDelegate.startNewSession must guard the session window content view before adding the skin")
+    session_start = app_delegate.find("func startNewSession(device:AVCaptureDevice)")
+    session_end = app_delegate.find("func refreshDevices()", session_start)
+    session_setup = app_delegate[session_start:session_end]
+    for fragment in (
+        "func startNewSession(device:AVCaptureDevice) -> Skin?",
+        "guard let contentView = window.contentView else",
+        "return nil",
+        "let skin = Skin(frame: frameView)",
+        "contentView.addSubview(skin)",
+    ):
+        if session_start < 0 or session_end < 0 or fragment not in session_setup:
+            errors.append(f"AppDelegate session creation must retain failable setup via {fragment!r}")
+    if session_setup.find("guard let contentView = window.contentView else") > session_setup.find("let skin = Skin(frame: frameView)"):
+        errors.append("AppDelegate must guard the session window content view before constructing the capture skin")
+    refresh_start = app_delegate.find("func refreshDevices()")
+    refresh_setup = app_delegate[refresh_start:]
+    if "if let skin = startNewSession(device: device)" not in refresh_setup:
+        errors.append("AppDelegate must register only successfully created device sessions")
+    if "self.deviceSessions[device] = startNewSession(device: device)" in refresh_setup:
+        errors.append("AppDelegate must not register a failable device session unconditionally")
+    if SESSION_REGISTRATION_PLAN.exists():
+        plan = SESSION_REGISTRATION_PLAN.read_text(encoding="utf-8")
+        for evidence in ("Status: Completed", "repository and external-directory `make check` passed", "hostile session-registration mutations were rejected"):
+            if evidence not in plan:
+                errors.append(f"{SESSION_REGISTRATION_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}")
     if "self.window!.close()" in app_delegate or "self.window!.makeKeyAndOrderFront(NSApp)" in app_delegate:
         errors.append("AppDelegate.refreshDevices must not force unwrap the main device-list window")
     if "guard let window = self.window else" not in app_delegate:


### PR DESCRIPTION
## Summary
Make device-session creation failable and register only capture skins that attach to a window content view.

## Baseline
The prior setup returned and registered a detached Skin when the new window had no content view, leaving a running phantom session that blocked retry.

## Improvements
Guard content-view availability before constructing the capture skin, return nil on failure, and optional-bind successful creation before updating deviceSessions.

## Validation
Focused project and behavior contracts passed; repository and external-directory make check passed; four hostile session-registration mutations were rejected; exact diff, syntax, artifact, credential, and conflict-marker audits passed.

## Risk
Connected-device capture and unusual AppKit window construction still require manual macOS hardware validation; Linux used the documented static-only build path because xcodebuild is unavailable.

## Follow-Ups
Keep this PR stacked until its parent PR is reviewed; do not merge or close either PR without explicit authorization.