### PR TITLE
fix(capture): roll back rejected Skin device switches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,8 @@
 - See `SECURITY.md` for vulnerability reporting and safe research guidance.
 - See `VISION.md` for project direction and contribution guardrails.
 - See `docs/plans/2026-06-08-screenshare-baseline.md` for the canonical mirroring privacy and runtime-error baseline.
+- Skin capture device switch rollback preserves the prior working input when a
+  replacement cannot be constructed or admitted.
 - See `docs/plans/2026-06-08-device-archive-decoding.md` for the local device-settings archive guard.
 
 ## Agent workflow

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-16
+
+- Skin capture device switch rollback preserves the prior working input when a
+  replacement cannot be constructed or admitted.
+
 ## 2026-06-15
 
 - Made device-session creation failable so a missing window content view cannot

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 - Static behavior checks require capture device switch rollback: replacement
   inputs are prepared and validated before a failed switch restores the prior
   working input.
+- Skin capture device switch rollback preserves the prior working input when a
+  replacement cannot be constructed or admitted.
 - Static behavior checks also require document preview setup and aspect updates
   to optional-bind outlets, backing layers, input ports, and windows.
 - Skin preview and window guards optional-bind preview layers and resize-window

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,6 +54,8 @@ cannot host its capture skin.
   successful cast and falls back to an empty saved-settings list.
 - Capture device switch rollback must restore the prior working input when a
   replacement cannot be admitted, without logging device metadata.
+- Skin capture device switch rollback preserves the prior working input when a
+  replacement cannot be constructed or admitted.
 
 ## Mobile Privacy Notes
 

--- a/ScreenShare/Skin.swift
+++ b/ScreenShare/Skin.swift
@@ -175,43 +175,55 @@ class Skin: NSView {
             return self.input?.device
         }
         set {
-            self.session.beginConfiguration()
-            
-            if let input = self.input {
-                session.removeInput(input)
-                self.input = nil
-            }
-            
+            let replacementInput: AVCaptureDeviceInput?
             if let newDevice = newValue {
-                
                 do {
-                    let newDeviceInput = try AVCaptureDeviceInput(device: newDevice)
-                    
-                    self.session.sessionPreset = .high
-                    self.session.addInput(newDeviceInput)
-                    self.input = newDeviceInput
-                    
-                    // Register for notifications in format change which imply orientation change
-                    self.notifications.registerObserver(AVCaptureInput.Port.formatDescriptionDidChangeNotification, dispatchAsyncToMainQueue: true, block: {notif in
-                        self.updateAspect()
-                    })
-                    
-                    // load existing device settings that might have been previously saved
-                    getDeviceSettings(device: newDevice)
-                    
-                    
+                    replacementInput = try AVCaptureDeviceInput(device: newDevice)
                 } catch let error as NSError {
                     self.displayError(error: error)
+                    return
                 }
-                
+            } else {
+                replacementInput = nil
             }
-            
-            self.session.commitConfiguration()
-            
-            updateAspect()
-            
-            setThisAsSelectedDevice()
-            
+
+            self.session.beginConfiguration()
+            defer {
+                self.session.commitConfiguration()
+                self.updateAspect()
+                self.setThisAsSelectedDevice()
+            }
+
+            let previousInput = self.input
+            if let previousInput = previousInput {
+                self.session.removeInput(previousInput)
+            }
+            self.input = nil
+
+            guard let replacementInput = replacementInput else {
+                return
+            }
+
+            self.session.sessionPreset = .high
+            guard self.session.canAddInput(replacementInput) else {
+                if let previousInput = previousInput,
+                    self.session.canAddInput(previousInput) {
+                    self.session.addInput(previousInput)
+                    self.input = previousInput
+                }
+                NSLog("Skin capture session rejected the replacement device input.")
+                return
+            }
+
+            self.session.addInput(replacementInput)
+            self.input = replacementInput
+
+            // Register for format changes that imply orientation changes.
+            self.notifications.registerObserver(AVCaptureInput.Port.formatDescriptionDidChangeNotification, dispatchAsyncToMainQueue: true, block: { _ in
+                self.updateAspect()
+            })
+
+            getDeviceSettings(device: replacementInput.device)
         }
     }
     

--- a/VISION.md
+++ b/VISION.md
@@ -25,6 +25,8 @@ Priority:
 - Avoid ad hoc stdout logging from app Swift sources
 - Handle capture input setup failures without force-unwrapping error metadata
 - Preserve capture device switch rollback when replacement admission fails
+- Skin capture device switch rollback preserves the prior working input when a
+  replacement cannot be constructed or admitted
 - Keep preview aspect updates responsive to width and height changes
 - Keep document preview and aspect setup tolerant of missing nib or capture state
 - Keep Skin preview and window guards across AppKit lifecycle gaps

--- a/docs/plans/2026-06-16-skin-device-switch-rollback.md
+++ b/docs/plans/2026-06-16-skin-device-switch-rollback.md
@@ -1,0 +1,79 @@
+# Skin Device Switch Rollback
+
+Status: In Progress
+
+## Problem
+
+`Document.selectedDevice` protects capture input replacement with construction,
+admission, and rollback checks, but `Skin.selectedDevice` still removes the
+working input first and calls `addInput` without `canAddInput`. Construction or
+admission failure can therefore leave a skin session detached from its prior
+capture device.
+
+## Requirements
+
+1. Construct a requested replacement input before mutating the skin capture
+   session.
+2. Keep device replacement inside one balanced configuration transaction.
+3. Validate replacement admission with `canAddInput` before adding it.
+4. Restore the prior input when replacement construction or admission fails.
+5. Preserve nil-device removal, format-change observation, saved device
+   settings, aspect updates, selection state, session lifetime, and window UI.
+6. Log generic failures without device identifiers or other metadata.
+7. Add mutation-sensitive static contracts, synchronized guidance, and
+   truthful completion evidence.
+
+## Implementation Units
+
+### 1. Make skin input replacement transactional
+
+File: `ScreenShare/Skin.swift`
+
+Capture the prior input, prepare the replacement before configuration, remove
+the old input only after preparation, validate admission, and restore the prior
+input on rejection while preserving the existing success follow-up work.
+
+### 2. Protect rollback parity
+
+Files:
+
+- `scripts/check-screenshare-source.py`
+- `docs/plans/2026-06-16-skin-device-switch-rollback.md`
+
+Require method-scoped preparation ordering, one configuration transaction,
+admission checks, rollback, generic logging, nil-device behavior, guidance, and
+completed-plan evidence.
+
+### 3. Document both switch boundaries
+
+Files:
+
+- `AGENTS.md`
+- `README.md`
+- `SECURITY.md`
+- `VISION.md`
+- `CHANGES.md`
+
+Record that both document and skin capture paths preserve the prior working
+input when a replacement cannot be constructed or admitted.
+
+## Verification Plan
+
+- Capture the pre-change ordering and missing-admission-check evidence.
+- Run repository and external-directory `make check`.
+- Reject hostile preparation, admission, rollback, transaction, logging,
+  guidance, and plan-status mutations.
+- Audit the exact diff, Swift conflict markers, generated artifacts, modes,
+  whitespace, and credential patterns before shipping.
+- Capture one bounded exact-head hosted snapshot after push without polling.
+
+## Scope Boundaries
+
+- Do not change device discovery, one-device policy, session registration,
+  pointer handling, aspect layout, archive format, entitlements, or Xcode
+  project settings.
+- Do not expose device identifiers in logs.
+- Do not claim local Xcode, camera-device, capture-session, or UI execution on
+  Linux.
+- The successor PR will be stacked on open PR #16; neither pull request may be
+  merged or closed without explicit authorization.

--- a/docs/plans/2026-06-16-skin-device-switch-rollback.md
+++ b/docs/plans/2026-06-16-skin-device-switch-rollback.md
@@ -1,6 +1,6 @@
 # Skin Device Switch Rollback
 
-Status: In Progress
+Status: Completed
 
 ## Problem
 
@@ -77,3 +77,16 @@ input when a replacement cannot be constructed or admitted.
   Linux.
 - The successor PR will be stacked on open PR #16; neither pull request may be
   merged or closed without explicit authorization.
+
+## Verification Completed
+
+- Pre-change inspection showed Skin removing its working input before
+  replacement construction and calling `addInput` without `canAddInput`.
+- repository and external-directory `make check` passed with project and
+  behavior contracts; Linux truthfully skipped unavailable `xcodebuild`.
+- hostile Skin device-switch mutations were rejected.
+- generated-artifact and credential-pattern audits passed for the intended
+  diff; the pre-existing tracked `ScreenShare/Images.xcassets/.DS_Store`
+  remained unchanged.
+- No local Xcode build, camera device, capture session, AppKit UI, credentials,
+  or deployment was exercised.

--- a/scripts/check-screenshare-source.py
+++ b/scripts/check-screenshare-source.py
@@ -18,6 +18,7 @@ SKIN_PREVIEW_WINDOW_PLAN = DOCS_PLANS / "2026-06-14-skin-preview-window-guards.m
 SKIN_ASPECT_LAYOUT_PLAN = DOCS_PLANS / "2026-06-14-skin-aspect-layout-guards.md"
 SKIN_POINTER_WINDOW_PLAN = DOCS_PLANS / "2026-06-15-skin-pointer-window-guards.md"
 SESSION_REGISTRATION_PLAN = DOCS_PLANS / "2026-06-15-session-registration-guard.md"
+SKIN_DEVICE_SWITCH_PLAN = DOCS_PLANS / "2026-06-16-skin-device-switch-rollback.md"
 EXPECTED_WORKFLOW = """name: Check
 
 on:
@@ -120,6 +121,8 @@ def docs_plan_checks():
         errors.append("docs/plans/2026-06-15-skin-pointer-window-guards.md is missing")
     if not SESSION_REGISTRATION_PLAN.exists():
         errors.append("docs/plans/2026-06-15-session-registration-guard.md is missing")
+    if not SKIN_DEVICE_SWITCH_PLAN.exists():
+        errors.append("docs/plans/2026-06-16-skin-device-switch-rollback.md is missing")
 
     plans = sorted(DOCS_PLANS.glob("*.md")) if DOCS_PLANS.exists() else []
     if not plans:
@@ -194,6 +197,8 @@ def project_checks():
             errors.append(f"{doc_path} must document the GitHub Actions baseline")
         if "capture device switch rollback" not in document.lower():
             errors.append(f"{doc_path} must document capture device switch rollback")
+        if "skin capture device switch rollback preserves the prior working input" not in document.lower():
+            errors.append(f"{doc_path} must document Skin device switch rollback")
         if "device archive optional binding" not in document.lower():
             errors.append(f"{doc_path} must document device archive optional binding")
         if "skin preview and window guards" not in document.lower():
@@ -204,6 +209,8 @@ def project_checks():
             errors.append(f"{doc_path} must document Skin pointer and window guards")
     if str(SKIN_PREVIEW_WINDOW_PLAN.relative_to(ROOT)) not in read_text("README.md"):
         errors.append(f"README.md must reference {SKIN_PREVIEW_WINDOW_PLAN.relative_to(ROOT)}")
+    if "Skin capture device switch rollback preserves the prior working input" not in read_text("AGENTS.md"):
+        errors.append("AGENTS.md must document Skin device switch rollback")
 
     project = read_text("Screenshare.xcodeproj/project.pbxproj")
     for fragment in (
@@ -459,6 +466,16 @@ def behavior_checks():
         for evidence in ("Status: Completed", "repository and external-directory `make check` passed", "hostile session-registration mutations were rejected"):
             if evidence not in plan:
                 errors.append(f"{SESSION_REGISTRATION_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}")
+    if SKIN_DEVICE_SWITCH_PLAN.exists():
+        plan = SKIN_DEVICE_SWITCH_PLAN.read_text(encoding="utf-8")
+        for evidence in (
+            "Status: Completed",
+            "repository and external-directory `make check` passed",
+            "hostile Skin device-switch mutations were rejected",
+            "generated-artifact and credential-pattern audits passed",
+        ):
+            if evidence not in plan:
+                errors.append(f"{SKIN_DEVICE_SWITCH_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}")
     if "self.window!.close()" in app_delegate or "self.window!.makeKeyAndOrderFront(NSApp)" in app_delegate:
         errors.append("AppDelegate.refreshDevices must not force unwrap the main device-list window")
     if "guard let window = self.window else" not in app_delegate:
@@ -478,6 +495,36 @@ def behavior_checks():
         errors.append("Document.selectedDevice must restore the previous input when replacement admission fails")
     if 'NSLog("Capture session rejected the replacement device input.")' not in document:
         errors.append("Document.selectedDevice must log replacement rejection without device metadata")
+
+    skin_switch_start = skin.find("var selectedDevice : AVCaptureDevice?")
+    skin_switch_end = skin.find("func getVideoDimensions()", skin_switch_start)
+    skin_switch = skin[skin_switch_start:skin_switch_end]
+    for fragment in (
+        "let replacementInput: AVCaptureDeviceInput?",
+        "replacementInput = try AVCaptureDeviceInput(device: newDevice)",
+        "let previousInput = self.input",
+        "guard self.session.canAddInput(replacementInput) else",
+        "self.session.canAddInput(previousInput)",
+        "self.session.addInput(previousInput)\n                    self.input = previousInput",
+        'NSLog("Skin capture session rejected the replacement device input.")',
+        "guard let replacementInput = replacementInput else",
+        "getDeviceSettings(device: replacementInput.device)",
+    ):
+        if skin_switch_start < 0 or skin_switch_end < 0 or fragment not in skin_switch:
+            errors.append(f"Skin.selectedDevice must retain transactional replacement via {fragment!r}")
+    replacement_build = skin_switch.find("replacementInput = try AVCaptureDeviceInput(device: newDevice)")
+    configuration_start = skin_switch.find("self.session.beginConfiguration()")
+    previous_removal = skin_switch.find("self.session.removeInput(previousInput)")
+    admission_check = skin_switch.find("guard self.session.canAddInput(replacementInput) else")
+    replacement_add = skin_switch.find("self.session.addInput(replacementInput)")
+    if min(replacement_build, configuration_start, previous_removal, admission_check, replacement_add) < 0 or not (
+        replacement_build < configuration_start < previous_removal < admission_check < replacement_add
+    ):
+        errors.append("Skin.selectedDevice must prepare, configure, validate, and add replacements in order")
+    if skin_switch.count("beginConfiguration()") != 1 or skin_switch.count("commitConfiguration()") != 1:
+        errors.append("Skin.selectedDevice must keep one balanced configuration transaction")
+    if "defer {\n                self.session.commitConfiguration()\n                self.updateAspect()\n                self.setThisAsSelectedDevice()\n            }" not in skin_switch:
+        errors.append("Skin.selectedDevice must preserve post-transaction aspect and selection updates")
 
     for swift_path in sorted((ROOT / "ScreenShare").glob("*.swift")):
         for line_number, line in enumerate(swift_path.read_text(encoding="utf-8").splitlines(), 1):


### PR DESCRIPTION
## Summary

Skin device switches no longer discard the working capture input before knowing whether the replacement can be constructed and admitted. Construction failure leaves the current input untouched, admission failure restores it inside the same configuration transaction, and generic diagnostics avoid exposing device metadata.

The existing format-change observation, saved settings, aspect refresh, nil-device removal, and selection updates remain intact. This brings the Skin path up to the transactional replacement boundary already enforced for document capture.

## Baseline

The Skin capture path removed the working input before replacement construction and attempted admission without first checking `canAddInput`. A construction or admission failure could therefore discard a usable capture input instead of preserving or restoring it.

## Improvements

- Construct replacement capture inputs before mutating the active session.
- Validate replacement admission and restore the prior working input inside one balanced configuration transaction when admission fails.
- Preserve nil-device removal, format-change observation, saved settings, aspect refresh, selection state, session lifetime, and window behavior.
- Add method-scoped ordering contracts, mutation coverage, synchronized guidance, and completed plan evidence.

## Validation

- `make check`
- External-directory `make check`
- Eight hostile Skin device-switch mutations
- Repository and external-directory checks passed shell syntax, project, and behavior contracts.
- Linux truthfully skipped unavailable `xcodebuild` after static checks passed.
- The initial exact-head snapshot reported `contract` successful and the hosted unsigned macOS `build` still in progress; no polling or rerun was performed.

## Risk

- Local Linux validation cannot compile or execute the macOS app; hosted unsigned compilation was still nonterminal in the bounded snapshot.
- Interactive camera-device switching, capture-session admission, AppKit window behavior, and rollback were not exercised with hardware.
- The exact head is mergeable, but terminal hosted validation must not be inferred while the macOS build remains in progress.

## Follow-Ups

- Preserve stacked ordering: PR #17 is based on open PR #16, and neither pull request should be merged or closed outside the established sequence.
- Reobserve this exact head only when a later bounded incremental interval returns it.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
