### PR TITLE
fix(capture): reject unattached initial Skin sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,8 @@
 - See `docs/plans/2026-06-08-screenshare-baseline.md` for the canonical mirroring privacy and runtime-error baseline.
 - Skin capture device switch rollback preserves the prior working input when a
   replacement cannot be constructed or admitted.
+- Initial Skin sessions reject unattached capture devices before window and
+  view attachment.
 - See `docs/plans/2026-06-08-device-archive-decoding.md` for the local device-settings archive guard.
 
 ## Agent workflow

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-17
+
+- Initial Skin sessions reject unattached capture devices before window and
+  view attachment.
+
 ## 2026-06-16
 
 - Skin capture device switch rollback preserves the prior working input when a

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
   working input.
 - Skin capture device switch rollback preserves the prior working input when a
   replacement cannot be constructed or admitted.
+- Initial Skin sessions reject unattached capture devices before window and
+  view attachment.
 - Static behavior checks also require document preview setup and aspect updates
   to optional-bind outlets, backing layers, input ports, and windows.
 - Skin preview and window guards optional-bind preview layers and resize-window
@@ -166,6 +168,9 @@ When the required SDK or runtime is unavailable, use static checks and source re
   macOS build gate.
 - See `docs/plans/2026-06-10-document-aspect-timer-teardown.md` for repeating
   preview timer lifecycle cleanup.
+- See `docs/plans/2026-06-17-initial-skin-device-attachment-guard.md` for
+  rejecting initial sessions that fail to attach their requested capture
+  device.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -56,6 +56,8 @@ cannot host its capture skin.
   replacement cannot be admitted, without logging device metadata.
 - Skin capture device switch rollback preserves the prior working input when a
   replacement cannot be constructed or admitted.
+- Initial Skin sessions reject unattached capture devices before window and
+  view attachment.
 
 ## Mobile Privacy Notes
 

--- a/ScreenShare/AppDelegate.swift
+++ b/ScreenShare/AppDelegate.swift
@@ -124,6 +124,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         
         let skin = Skin(frame: frameView)
         skin.initWithDevice(device: device)
+        guard skin.selectedDevice == device else {
+            skin.endSession()
+            return nil
+        }
         skin.ownerWindow = window
         contentView.addSubview(skin)
         

--- a/VISION.md
+++ b/VISION.md
@@ -27,6 +27,8 @@ Priority:
 - Preserve capture device switch rollback when replacement admission fails
 - Skin capture device switch rollback preserves the prior working input when a
   replacement cannot be constructed or admitted
+- Initial Skin sessions reject unattached capture devices before window and
+  view attachment
 - Keep preview aspect updates responsive to width and height changes
 - Keep document preview and aspect setup tolerant of missing nib or capture state
 - Keep Skin preview and window guards across AppKit lifecycle gaps

--- a/docs/plans/2026-06-17-initial-skin-device-attachment-guard.md
+++ b/docs/plans/2026-06-17-initial-skin-device-attachment-guard.md
@@ -6,7 +6,7 @@ date: 2026-06-17
 
 # Reject Initial Skin Sessions Without a Capture Input
 
-Status: In Progress
+Status: Completed
 
 ## Context
 
@@ -61,7 +61,12 @@ session has no capture input and blocks the connected-device retry path.
 
 ## Verification
 
-- Planned: focused project and behavior source contracts.
-- Planned: hostile initial-attachment mutations.
-- Planned: repository and external-directory `make check` on Linux.
-- Planned: exact-head hosted macOS build.
+- Focused project and behavior source contracts passed.
+- Five hostile initial Skin attachment mutations were rejected: removed guard,
+  inverted device match, late guard after view attachment, removed failed-session
+  cleanup, and removed nil return.
+- The repository and external-directory `make check` passed on Linux; the
+  portable gate reported the expected unavailable `xcodebuild`.
+- Exact-diff, generated-artifact and credential-pattern audits passed.
+- The exact-head hosted macOS build remains required for Apple-framework
+  compilation evidence.

--- a/docs/plans/2026-06-17-initial-skin-device-attachment-guard.md
+++ b/docs/plans/2026-06-17-initial-skin-device-attachment-guard.md
@@ -1,0 +1,67 @@
+---
+title: Reject Initial Skin Sessions Without a Capture Input
+type: fix
+date: 2026-06-17
+---
+
+# Reject Initial Skin Sessions Without a Capture Input
+
+Status: In Progress
+
+## Context
+
+`Skin.selectedDevice` now preserves a working input when replacement
+construction or admission fails. Initial session creation has no prior input,
+however, and `AppDelegate.startNewSession` continues attaching, showing, and
+registering the skin even when that first device assignment failed. The phantom
+session has no capture input and blocks the connected-device retry path.
+
+## Requirements
+
+- R1. Verify the new skin is attached to the requested capture device before
+  assigning its window or attaching its view.
+- R2. End the failed skin session and return `nil` when initial input
+  construction or admission leaves it unattached.
+- R3. Keep notification registration, aspect setup, window presentation, and
+  `deviceSessions` insertion limited to successfully attached skins.
+- R4. Preserve the one-device policy and the existing transactional device
+  switch rollback behavior.
+- R5. Add mutation-sensitive static coverage for missing, inverted, late, or
+  cleanup-free attachment guards.
+- R6. Keep Linux validation portable and require the exact-head hosted macOS
+  build for Apple-framework compilation evidence.
+
+## Scope Boundaries
+
+- Do not redesign `Skin.initWithDevice`, device discovery, or capture session
+  ownership.
+- Do not add dependencies or weaken the existing contract and hosted build
+  gates.
+
+## Implementation Units
+
+### U1. Guard initial skin attachment
+
+- **Goal:** Fail session creation before window/view side effects when the
+  requested device did not become the skin's active input.
+- **Files:** `ScreenShare/AppDelegate.swift`
+- **Verification:** Source contract rejects missing, inverted, late, and
+  cleanup-free guard mutations.
+
+### U2. Make the startup boundary durable
+
+- **Goal:** Register the guard in the portable checker and synchronize project
+  guidance and evidence.
+- **Files:** `scripts/check-screenshare-source.py`, `README.md`, `CHANGES.md`,
+  `AGENTS.md`, `VISION.md`, `SECURITY.md`,
+  `docs/plans/2026-06-17-initial-skin-device-attachment-guard.md`
+- **Verification:** Repository and external-directory `make check`, explicit
+  hostile mutations, and generated-artifact, recording-file, and credential
+  audits.
+
+## Verification
+
+- Planned: focused project and behavior source contracts.
+- Planned: hostile initial-attachment mutations.
+- Planned: repository and external-directory `make check` on Linux.
+- Planned: exact-head hosted macOS build.

--- a/scripts/check-screenshare-source.py
+++ b/scripts/check-screenshare-source.py
@@ -19,6 +19,7 @@ SKIN_ASPECT_LAYOUT_PLAN = DOCS_PLANS / "2026-06-14-skin-aspect-layout-guards.md"
 SKIN_POINTER_WINDOW_PLAN = DOCS_PLANS / "2026-06-15-skin-pointer-window-guards.md"
 SESSION_REGISTRATION_PLAN = DOCS_PLANS / "2026-06-15-session-registration-guard.md"
 SKIN_DEVICE_SWITCH_PLAN = DOCS_PLANS / "2026-06-16-skin-device-switch-rollback.md"
+INITIAL_SKIN_ATTACHMENT_PLAN = DOCS_PLANS / "2026-06-17-initial-skin-device-attachment-guard.md"
 EXPECTED_WORKFLOW = """name: Check
 
 on:
@@ -123,6 +124,8 @@ def docs_plan_checks():
         errors.append("docs/plans/2026-06-15-session-registration-guard.md is missing")
     if not SKIN_DEVICE_SWITCH_PLAN.exists():
         errors.append("docs/plans/2026-06-16-skin-device-switch-rollback.md is missing")
+    if not INITIAL_SKIN_ATTACHMENT_PLAN.exists():
+        errors.append("docs/plans/2026-06-17-initial-skin-device-attachment-guard.md is missing")
 
     plans = sorted(DOCS_PLANS.glob("*.md")) if DOCS_PLANS.exists() else []
     if not plans:
@@ -207,10 +210,15 @@ def project_checks():
             errors.append(f"{doc_path} must document Skin aspect layout guards")
         if "skin pointer and window guards" not in document.lower():
             errors.append(f"{doc_path} must document Skin pointer and window guards")
+        if "initial skin sessions reject unattached capture devices before window and view attachment" not in document.lower():
+            errors.append(f"{doc_path} must document initial Skin attachment rejection")
     if str(SKIN_PREVIEW_WINDOW_PLAN.relative_to(ROOT)) not in read_text("README.md"):
         errors.append(f"README.md must reference {SKIN_PREVIEW_WINDOW_PLAN.relative_to(ROOT)}")
     if "Skin capture device switch rollback preserves the prior working input" not in read_text("AGENTS.md"):
         errors.append("AGENTS.md must document Skin device switch rollback")
+    agents = re.sub(r"\s+", " ", read_text("AGENTS.md"))
+    if "Initial Skin sessions reject unattached capture devices before window and view attachment" not in agents:
+        errors.append("AGENTS.md must document initial Skin attachment rejection")
 
     project = read_text("Screenshare.xcodeproj/project.pbxproj")
     for fragment in (
@@ -455,6 +463,24 @@ def behavior_checks():
             errors.append(f"AppDelegate session creation must retain failable setup via {fragment!r}")
     if session_setup.find("guard let contentView = window.contentView else") > session_setup.find("let skin = Skin(frame: frameView)"):
         errors.append("AppDelegate must guard the session window content view before constructing the capture skin")
+    attachment_start = session_setup.find("guard skin.selectedDevice == device else")
+    owner_assignment = session_setup.find("skin.ownerWindow = window")
+    attachment_guard = session_setup[attachment_start:owner_assignment]
+    if "skin.initWithDevice(device: device)" not in session_setup:
+        errors.append("AppDelegate initial skin attachment must initialize the requested device")
+    for fragment in (
+        "guard skin.selectedDevice == device else",
+        "skin.endSession()",
+        "return nil",
+    ):
+        if attachment_start < 0 or owner_assignment < 0 or fragment not in attachment_guard:
+            errors.append(f"AppDelegate initial skin attachment must retain guard via {fragment!r}")
+    initialization = session_setup.find("skin.initWithDevice(device: device)")
+    view_attachment = session_setup.find("contentView.addSubview(skin)")
+    if min(initialization, attachment_start, owner_assignment, view_attachment) < 0 or not (
+        initialization < attachment_start < owner_assignment < view_attachment
+    ):
+        errors.append("AppDelegate must validate initial capture input before window and view attachment")
     refresh_start = app_delegate.find("func refreshDevices()")
     refresh_setup = app_delegate[refresh_start:]
     if "if let skin = startNewSession(device: device)" not in refresh_setup:
@@ -476,6 +502,18 @@ def behavior_checks():
         ):
             if evidence not in plan:
                 errors.append(f"{SKIN_DEVICE_SWITCH_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}")
+    if INITIAL_SKIN_ATTACHMENT_PLAN.exists():
+        plan = INITIAL_SKIN_ATTACHMENT_PLAN.read_text(encoding="utf-8")
+        for evidence in (
+            "Status: Completed",
+            "repository and external-directory `make check` passed",
+            "hostile initial Skin attachment mutations were rejected",
+            "generated-artifact and credential-pattern audits passed",
+        ):
+            if evidence not in plan:
+                errors.append(f"{INITIAL_SKIN_ATTACHMENT_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}")
+        if str(INITIAL_SKIN_ATTACHMENT_PLAN.relative_to(ROOT)) not in read_text("README.md"):
+            errors.append(f"README.md must reference {INITIAL_SKIN_ATTACHMENT_PLAN.relative_to(ROOT)}")
     if "self.window!.close()" in app_delegate or "self.window!.makeKeyAndOrderFront(NSApp)" in app_delegate:
         errors.append("AppDelegate.refreshDevices must not force unwrap the main device-list window")
     if "guard let window = self.window else" not in app_delegate:


### PR DESCRIPTION
## Summary

ScreenShare no longer presents or registers a device skin when its first capture input could not be constructed or admitted. The failed session is stopped before it acquires window ownership or view/observer side effects, allowing device discovery to retry instead of being blocked by a phantom active session.

## Baseline

This PR is stacked on #17 and complements its transactional replacement rollback. Existing device switching, one-device policy, successful window presentation, and session registration remain unchanged.

## Improvements

- Verify the requested device became the new skin’s active input immediately after initialization.
- Stop and reject failed initial sessions before window ownership and view attachment.
- Lock the ordering and cleanup boundary with five hostile source mutations.
- Synchronize maintenance, security, changelog, and plan evidence.

## Validation

- Repository and external-directory `make check` on Linux
- Project and behavior source contracts
- Five initial-attachment mutations rejected: removed guard, inverted match, late guard, removed cleanup, and removed nil return
- Exact eight-path diff, generated-artifact, recording-file, mode/binary, and credential-pattern audits

`xcodebuild` is unavailable in the Linux workspace. The exact-head hosted macOS build remains the Apple-framework compilation authority.

## Risk

The new equality check uses the same `AVCaptureDevice` identity semantics already used by device discovery and session maps. No connected-device capture, AppKit window presentation, or hardware disconnect was exercised locally.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required because this is a local macOS sample rather than a deployed service. During the first manual validation, connect a device whose capture input is rejected and confirm no skin window appears, the main device list remains available, and reconnecting can retry session creation.

## Follow-Ups

- Merge the stacked base PR before this PR; do not merge or close either automatically.
- Retain the hosted macOS build as required evidence before merge.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
