### PR TITLE
build: isolate ScreenShare Make authority

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,7 +42,7 @@ jobs:
           persist-credentials: false
 
       - name: Show Xcode version
-        run: xcodebuild -version
+        run: /usr/bin/xcodebuild -version
 
       - name: Build unsigned macOS app
         run: make build

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,12 @@
 
 ## 2026-06-21
 
-- Isolated Make verification authority from caller-controlled preload files,
-  file lists, shells, Python commands, Xcode builders, bytecode settings, and
-  repository roots, with 66 target/authority cases and rejection coverage.
+- Isolated checked-in Make recipes from caller-controlled shells, Python
+  commands, Xcode builders, bytecode settings, and repository roots, with 66
+  target/authority cases. Documented that `MAKEFILES` and additional `-f`
+  programs execute at GNU Make startup outside an in-Makefile trust boundary.
+- Pinned the documented native unit-test script and hosted Xcode probe to
+  `/usr/bin/xcodebuild` so caller `PATH` cannot replace application validation.
 
 ## 2026-06-19
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2026-06-21
+
+- Isolated Make verification authority from caller-controlled preload files,
+  file lists, shells, Python commands, Xcode builders, bytecode settings, and
+  repository roots, with 66 target/authority cases and rejection coverage.
+
 ## 2026-06-19
 
 - Initialized each Skin capture session before nib-backed preview setup and

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,6 @@
 
 override SHELL := /bin/sh
 override .SHELLFLAGS := -c
-override PYTHON := python3
-override XCODEBUILD := xcodebuild
 override PYTHONDONTWRITEBYTECODE := 1
 export PYTHONDONTWRITEBYTECODE
 ifneq ($(strip $(MAKEFILES)),)
@@ -19,18 +17,21 @@ export ROOT
 ifeq ($(strip $(ROOT)),)
 $(error repository Makefile path could not be resolved)
 endif
+override PYTHON := $(ROOT)/scripts/run-python.sh
+override XCODEBUILD := $(ROOT)/scripts/run-xcodebuild.sh
+export PYTHON XCODEBUILD
 
 lint:
 	/bin/sh -n "$$ROOT/build.sh"
-	$(PYTHON) "$$ROOT/scripts/check-screenshare-source.py" --mode project
+	"$$PYTHON" "$$ROOT/scripts/check-screenshare-source.py" --mode project
 
 test:
-	$(PYTHON) "$$ROOT/scripts/check-screenshare-source.py" --mode behavior
-	$(PYTHON) "$$ROOT/scripts/test-screenshare-contracts.py"
+	"$$PYTHON" "$$ROOT/scripts/check-screenshare-source.py" --mode behavior
+	"$$PYTHON" "$$ROOT/scripts/test-screenshare-contracts.py"
 
 build: lint
-	@if command -v $(XCODEBUILD) >/dev/null 2>&1; then \
-		cd "$$ROOT" && $(XCODEBUILD) -project Screenshare.xcodeproj -scheme Screenshare -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build; \
+	@if [ -x /usr/bin/xcodebuild ]; then \
+		cd "$$ROOT" && "$$XCODEBUILD" -project Screenshare.xcodeproj -scheme Screenshare -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build; \
 	else \
 		echo "xcodebuild not found; static project checks completed"; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,43 @@
-.PHONY: build check lint test verify
+.DEFAULT_GOAL := check
+.PHONY: build check lint root-test test verify
 
-PYTHON ?= python3
-XCODEBUILD ?= xcodebuild
-override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+override SHELL := /bin/sh
+override .SHELLFLAGS := -c
+override PYTHON := python3
+override XCODEBUILD := xcodebuild
+override PYTHONDONTWRITEBYTECODE := 1
+export PYTHONDONTWRITEBYTECODE
+ifneq ($(strip $(MAKEFILES)),)
+$(error MAKEFILES must be empty; repository verification requires this Makefile to be loaded alone)
+endif
+override MAKEFILES :=
+ifneq ($(origin MAKEFILE_LIST),file)
+$(error MAKEFILE_LIST must not be overridden)
+endif
+override ROOT := $(shell path='$(subst ','"'"',$(MAKEFILE_LIST))'; path=$$(printf '%s' "$$path" | /usr/bin/sed 's/^ //'); [ -f "$$path" ] || exit 1; directory=$$(/usr/bin/dirname -- "$$path"); CDPATH= cd -- "$$directory" && /bin/pwd -P)
+export ROOT
+ifeq ($(strip $(ROOT)),)
+$(error repository Makefile path could not be resolved)
+endif
 
 lint:
-	sh -n "$(ROOT)/build.sh"
-	$(PYTHON) "$(ROOT)/scripts/check-screenshare-source.py" --mode project
+	/bin/sh -n "$$ROOT/build.sh"
+	$(PYTHON) "$$ROOT/scripts/check-screenshare-source.py" --mode project
 
 test:
-	$(PYTHON) "$(ROOT)/scripts/check-screenshare-source.py" --mode behavior
-	$(PYTHON) "$(ROOT)/scripts/test-screenshare-contracts.py"
+	$(PYTHON) "$$ROOT/scripts/check-screenshare-source.py" --mode behavior
+	$(PYTHON) "$$ROOT/scripts/test-screenshare-contracts.py"
 
 build: lint
-	@if command -v "$(XCODEBUILD)" >/dev/null 2>&1; then \
-		"$(XCODEBUILD)" -project "$(ROOT)/Screenshare.xcodeproj" -scheme Screenshare -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build; \
+	@if command -v $(XCODEBUILD) >/dev/null 2>&1; then \
+		cd "$$ROOT" && $(XCODEBUILD) -project Screenshare.xcodeproj -scheme Screenshare -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build; \
 	else \
 		echo "xcodebuild not found; static project checks completed"; \
 	fi
 
-verify: lint test build
+root-test:
+	/bin/sh "$$ROOT/scripts/test-makefile-root.sh"
+
+verify: root-test lint test build
 
 check: verify

--- a/README.md
+++ b/README.md
@@ -172,8 +172,9 @@ When the required SDK or runtime is unavailable, use static checks and source re
   settings archive boundary.
 - See `docs/plans/2026-06-14-make-root-override-protection.md` for the
   caller-resistant, location-independent ScreenShare validation root.
-- See `docs/plans/2026-06-21-make-authority-isolation.md` for isolated Make
-  authority and hostile-input regression coverage.
+- See `docs/plans/2026-06-21-make-authority-isolation.md` for checked-in recipe
+  authority, hostile-input regression coverage, and the GNU Make preload and
+  additional-`-f` startup boundary.
 - See `docs/plans/2026-06-14-skin-preview-window-guards.md` for guarded Skin
   preview-layer and resize-window lifecycle setup.
 - See `docs/plans/2026-06-09-document-preview-guard.md` for the document

--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   settings archive boundary.
 - See `docs/plans/2026-06-14-make-root-override-protection.md` for the
   caller-resistant, location-independent ScreenShare validation root.
+- See `docs/plans/2026-06-21-make-authority-isolation.md` for isolated Make
+  authority and hostile-input regression coverage.
 - See `docs/plans/2026-06-14-skin-preview-window-guards.md` for guarded Skin
   preview-layer and resize-window lifecycle setup.
 - See `docs/plans/2026-06-09-document-preview-guard.md` for the document

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@
 set -eu
 
 ci_lib() {
-    xcodebuild -project Screenshare.xcodeproj \
+    /usr/bin/xcodebuild -project Screenshare.xcodeproj \
                -scheme "Screenshare" \
                -destination "platform=macOS" \
                CODE_SIGNING_ALLOWED=NO \

--- a/docs/plans/2026-06-14-make-root-override-protection.md
+++ b/docs/plans/2026-06-14-make-root-override-protection.md
@@ -13,7 +13,9 @@ redirect those commands away from the checkout.
 
 - **R1:** Prevent command-line and environment values from replacing the
   Makefile-derived repository root.
-- **R2:** Keep `PYTHON` and `XCODEBUILD` configurable.
+- **R2:** Keep the documented Python and Xcode tools. The Make
+  authority-isolation follow-up fixed both command names because they are part
+  of the trusted verification boundary.
 - **R3:** Require exactly one protected root declaration in the source checker.
 - **R4:** Preserve the declaration's existing Makefile position while proving
   every public alias from root and an external directory.

--- a/docs/plans/2026-06-21-make-authority-isolation.md
+++ b/docs/plans/2026-06-21-make-authority-isolation.md
@@ -1,0 +1,36 @@
+# Make Authority Isolation
+
+## Status: Completed
+
+## Context
+
+The protected repository root stopped direct `ROOT=/tmp` redirection, but GNU
+Make still accepted caller-controlled preload files, file lists, recipe shells,
+Python commands, and Xcode build commands. Those channels could replace static
+contracts or turn the hosted native build into a no-op.
+
+## Requirements
+
+- **R1:** Load the repository Makefile alone and reject overridden file lists.
+- **R2:** Derive the checkout root safely from the exact Makefile path.
+- **R3:** Fix the shell, Python command, Xcode build command, and bytecode
+  suppression.
+- **R4:** Exercise every public target across hostile authority inputs.
+- **R5:** Preserve all Swift, project, capture, settings, and signing behavior.
+
+## Implementation
+
+- Hardened Make authority before target definitions are evaluated.
+- Added a macOS-portable `root-test` checkout with spaces, quotes, and
+  command-substitution syntax in its path.
+- Covered all six public targets across eleven authority modes plus explicit
+  file-list, preload, and multiple-Makefile rejection cases.
+- Left Swift source, Xcode project, entitlements, and application behavior
+  unchanged.
+
+## Verification
+
+- `make root-test` passed 66 target/authority cases and four rejection cases.
+- `make check` passed from the repository and through an absolute Makefile path.
+- Python and shell syntax checks, `git diff --check`, and repository integrity
+  screening passed.

--- a/docs/plans/2026-06-21-make-authority-isolation.md
+++ b/docs/plans/2026-06-21-make-authority-isolation.md
@@ -4,14 +4,16 @@
 
 ## Context
 
-The protected repository root stopped direct `ROOT=/tmp` redirection, but GNU
-Make still accepted caller-controlled preload files, file lists, recipe shells,
-Python commands, and Xcode build commands. Those channels could replace static
-contracts or turn the hosted native build into a no-op.
+The protected repository root stopped direct `ROOT=/tmp` redirection. Once the
+checked-in Makefile begins evaluation, it can also pin recipe shells, Python
+commands, Xcode build commands, bytecode settings, and its repository root.
+GNU Make preload files and additional `-f` programs are different: they are
+evaluated during startup, before an in-Makefile guard can establish authority.
 
 ## Requirements
 
-- **R1:** Load the repository Makefile alone and reject overridden file lists.
+- **R1:** Fail closed when startup metadata already exposes preload or earlier
+  Makefiles, and document that their code may already have executed.
 - **R2:** Derive the checkout root safely from the exact Makefile path.
 - **R3:** Fix the shell, Python command, Xcode build command, and bytecode
   suppression.
@@ -20,17 +22,29 @@ contracts or turn the hosted native build into a no-op.
 
 ## Implementation
 
-- Hardened Make authority before target definitions are evaluated.
+- Hardened recipe authority from the point the checked-in Makefile is evaluated.
 - Added a macOS-portable `root-test` checkout with spaces, quotes, and
   command-substitution syntax in its path.
-- Covered all six public targets across eleven authority modes plus explicit
-  file-list, preload, and multiple-Makefile rejection cases.
+- Covered all six public targets across eleven authority modes, explicit
+  file-list rejections, and the GNU Make startup boundary for `MAKEFILES`,
+  earlier `-f`, and later `-f` programs.
 - Left Swift source, Xcode project, entitlements, and application behavior
   unchanged.
 
 ## Verification
 
-- `make root-test` passed 66 target/authority cases and four rejection cases.
+- `make root-test` passed 66 target/authority cases, two metadata rejection
+  cases, and three startup-boundary cases.
 - `make check` passed from the repository and through an absolute Makefile path.
 - Python and shell syntax checks, `git diff --check`, and repository integrity
   screening passed.
+
+## Trust Boundary
+
+The checked-in Makefile cannot make an already-started GNU Make process safe
+against caller-supplied programs. A `MAKEFILES` preload or an earlier `-f`
+program can execute while GNU Make is loading files, before this Makefile can
+reject the visible metadata. A later `-f` program can replace recipes after
+this Makefile has been read. Trusted automation must therefore invoke this
+Makefile without `MAKEFILES` or additional `-f` arguments; the guards diagnose
+misuse but are not a sandbox for hostile GNU Make startup inputs.

--- a/scripts/check-screenshare-source.py
+++ b/scripts/check-screenshare-source.py
@@ -65,7 +65,7 @@ jobs:
           persist-credentials: false
 
       - name: Show Xcode version
-        run: xcodebuild -version
+        run: /usr/bin/xcodebuild -version
 
       - name: Build unsigned macOS app
         run: make build
@@ -153,7 +153,7 @@ def project_checks():
     if re.search(r"\bfunction\s+[A-Za-z_][A-Za-z0-9_]*\s*\(", build_script):
         errors.append("build.sh must use POSIX shell function syntax")
     for fragment in (
-        "xcodebuild -project Screenshare.xcodeproj",
+        "/usr/bin/xcodebuild -project Screenshare.xcodeproj",
         '-scheme "Screenshare"',
         '-destination "platform=macOS"',
         "CODE_SIGNING_ALLOWED=NO",
@@ -218,6 +218,10 @@ def project_checks():
         if fragment not in launcher:
             errors.append(f"{relative_path} must use the trusted absolute tool launcher")
 
+    mutation_tests = read_text("scripts/test-screenshare-contracts.py")
+    if 'str(repository / "scripts/run-python.sh")' not in mutation_tests:
+        errors.append("contract mutation tests must use the isolated repository Python launcher")
+
     if MAKE_ROOT_PLAN.exists():
         root_plan = MAKE_ROOT_PLAN.read_text(encoding="utf-8")
         for evidence in (
@@ -240,8 +244,8 @@ def project_checks():
         for evidence in (
             "66 executed target/authority cases",
             "MAKEFILE_LIST must not be overridden",
-            "MAKEFILES must be empty",
-            "repository Makefile path could not be resolved",
+            "3 documented GNU Make startup-boundary cases",
+            "later-startup-ran",
         ):
             if evidence not in root_test_text:
                 errors.append(f"{root_test.relative_to(ROOT)} must preserve {evidence!r}")
@@ -252,7 +256,8 @@ def project_checks():
         authority_plan = MAKE_AUTHORITY_PLAN.read_text(encoding="utf-8")
         for evidence in (
             "Status: Completed",
-            "`make root-test` passed 66 target/authority cases and four rejection cases",
+            "`make root-test` passed 66 target/authority cases, two metadata rejection",
+            "checked-in Makefile cannot make an already-started GNU Make process safe",
             "`make check` passed from the repository and through an absolute Makefile path",
         ):
             if evidence not in authority_plan:

--- a/scripts/check-screenshare-source.py
+++ b/scripts/check-screenshare-source.py
@@ -186,8 +186,9 @@ def project_checks():
         ".DEFAULT_GOAL := check",
         "override SHELL := /bin/sh",
         "override .SHELLFLAGS := -c",
-        "override PYTHON := python3",
-        "override XCODEBUILD := xcodebuild",
+        "override PYTHON := $(ROOT)/scripts/run-python.sh",
+        "override XCODEBUILD := $(ROOT)/scripts/run-xcodebuild.sh",
+        "export PYTHON XCODEBUILD",
         "override PYTHONDONTWRITEBYTECODE := 1",
         "export PYTHONDONTWRITEBYTECODE",
         "$(error MAKEFILES must be empty; repository verification requires this Makefile to be loaded alone)",
@@ -197,9 +198,9 @@ def project_checks():
         "export ROOT",
         "$(error repository Makefile path could not be resolved)",
         '\t/bin/sh -n "$$ROOT/build.sh"',
-        '$(PYTHON) "$$ROOT/scripts/check-screenshare-source.py" --mode project',
-        '$(PYTHON) "$$ROOT/scripts/test-screenshare-contracts.py"',
-        'cd "$$ROOT" && $(XCODEBUILD) -project Screenshare.xcodeproj',
+        '"$$PYTHON" "$$ROOT/scripts/check-screenshare-source.py" --mode project',
+        '"$$PYTHON" "$$ROOT/scripts/test-screenshare-contracts.py"',
+        'cd "$$ROOT" && "$$XCODEBUILD" -project Screenshare.xcodeproj',
         "CODE_SIGNING_ALLOWED=NO build",
         "root-test:",
         '\t/bin/sh "$$ROOT/scripts/test-makefile-root.sh"',
@@ -207,6 +208,15 @@ def project_checks():
     ):
         if fragment not in makefile:
             errors.append(f"Makefile is missing root-independent fragment: {fragment}")
+
+    expected_launchers = {
+        "scripts/run-python.sh": "exec /usr/bin/python3 -I -B -c",
+        "scripts/run-xcodebuild.sh": 'exec /usr/bin/xcodebuild "$@"',
+    }
+    for relative_path, fragment in expected_launchers.items():
+        launcher = read_text(relative_path)
+        if fragment not in launcher:
+            errors.append(f"{relative_path} must use the trusted absolute tool launcher")
 
     if MAKE_ROOT_PLAN.exists():
         root_plan = MAKE_ROOT_PLAN.read_text(encoding="utf-8")

--- a/scripts/check-screenshare-source.py
+++ b/scripts/check-screenshare-source.py
@@ -14,6 +14,7 @@ CI_PLAN = DOCS_PLANS / "2026-06-10-ci-baseline.md"
 DEVICE_SWITCH_ROLLBACK_PLAN = DOCS_PLANS / "2026-06-13-device-switch-rollback.md"
 DEVICE_ARCHIVE_BINDING_PLAN = DOCS_PLANS / "2026-06-13-device-archive-optional-binding.md"
 MAKE_ROOT_PLAN = DOCS_PLANS / "2026-06-14-make-root-override-protection.md"
+MAKE_AUTHORITY_PLAN = DOCS_PLANS / "2026-06-21-make-authority-isolation.md"
 SKIN_PREVIEW_WINDOW_PLAN = DOCS_PLANS / "2026-06-14-skin-preview-window-guards.md"
 SKIN_ASPECT_LAYOUT_PLAN = DOCS_PLANS / "2026-06-14-skin-aspect-layout-guards.md"
 SKIN_POINTER_WINDOW_PLAN = DOCS_PLANS / "2026-06-15-skin-pointer-window-guards.md"
@@ -114,6 +115,8 @@ def docs_plan_checks():
         errors.append("docs/plans/2026-06-13-device-archive-optional-binding.md is missing")
     if not MAKE_ROOT_PLAN.exists():
         errors.append("docs/plans/2026-06-14-make-root-override-protection.md is missing")
+    if not MAKE_AUTHORITY_PLAN.exists():
+        errors.append("docs/plans/2026-06-21-make-authority-isolation.md is missing")
     if not SKIN_PREVIEW_WINDOW_PLAN.exists():
         errors.append("docs/plans/2026-06-14-skin-preview-window-guards.md is missing")
     if not SKIN_ASPECT_LAYOUT_PLAN.exists():
@@ -171,22 +174,36 @@ def project_checks():
         errors.append("GitHub Actions workflow must match the reviewed credential-free contract and macOS build baseline")
 
     makefile = read_text("Makefile")
-    root_declaration = "override ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))"
+    root_declaration = "override ROOT := $(shell path='$(subst ','\"'\"',$(MAKEFILE_LIST))'; path=$$(printf '%s' \"$$path\" | /usr/bin/sed 's/^ //'); [ -f \"$$path\" ] || exit 1; directory=$$(/usr/bin/dirname -- \"$$path\"); CDPATH= cd -- \"$$directory\" && /bin/pwd -P)"
     root_assignments = [
         line
         for line in makefile.splitlines()
         if re.match(r"^(?:override\s+)?ROOT\s*[:?+]?=", line)
     ]
     if root_assignments != [root_declaration]:
-        errors.append(
-            "Makefile must define exactly one protected repository-derived ROOT declaration"
-        )
+        errors.append("Makefile must define exactly one safe repository-derived ROOT declaration")
     for fragment in (
+        ".DEFAULT_GOAL := check",
+        "override SHELL := /bin/sh",
+        "override .SHELLFLAGS := -c",
+        "override PYTHON := python3",
+        "override XCODEBUILD := xcodebuild",
+        "override PYTHONDONTWRITEBYTECODE := 1",
+        "export PYTHONDONTWRITEBYTECODE",
+        "$(error MAKEFILES must be empty; repository verification requires this Makefile to be loaded alone)",
+        "override MAKEFILES :=",
+        "$(error MAKEFILE_LIST must not be overridden)",
         root_declaration,
-        '"$(ROOT)/build.sh"',
-        '"$(ROOT)/scripts/check-screenshare-source.py"',
-        '"$(ROOT)/Screenshare.xcodeproj"',
-        "CODE_SIGNING_ALLOWED=NO",
+        "export ROOT",
+        "$(error repository Makefile path could not be resolved)",
+        '\t/bin/sh -n "$$ROOT/build.sh"',
+        '$(PYTHON) "$$ROOT/scripts/check-screenshare-source.py" --mode project',
+        '$(PYTHON) "$$ROOT/scripts/test-screenshare-contracts.py"',
+        'cd "$$ROOT" && $(XCODEBUILD) -project Screenshare.xcodeproj',
+        "CODE_SIGNING_ALLOWED=NO build",
+        "root-test:",
+        '\t/bin/sh "$$ROOT/scripts/test-makefile-root.sh"',
+        "verify: root-test lint test build",
     ):
         if fragment not in makefile:
             errors.append(f"Makefile is missing root-independent fragment: {fragment}")
@@ -206,6 +223,34 @@ def project_checks():
                 )
         if str(MAKE_ROOT_PLAN.relative_to(ROOT)) not in read_text("README.md"):
             errors.append(f"README.md must reference {MAKE_ROOT_PLAN.relative_to(ROOT)}")
+
+    root_test = ROOT / "scripts" / "test-makefile-root.sh"
+    if root_test.exists():
+        root_test_text = root_test.read_text(encoding="utf-8")
+        for evidence in (
+            "66 executed target/authority cases",
+            "MAKEFILE_LIST must not be overridden",
+            "MAKEFILES must be empty",
+            "repository Makefile path could not be resolved",
+        ):
+            if evidence not in root_test_text:
+                errors.append(f"{root_test.relative_to(ROOT)} must preserve {evidence!r}")
+    else:
+        errors.append("scripts/test-makefile-root.sh is missing")
+
+    if MAKE_AUTHORITY_PLAN.exists():
+        authority_plan = MAKE_AUTHORITY_PLAN.read_text(encoding="utf-8")
+        for evidence in (
+            "Status: Completed",
+            "`make root-test` passed 66 target/authority cases and four rejection cases",
+            "`make check` passed from the repository and through an absolute Makefile path",
+        ):
+            if evidence not in authority_plan:
+                errors.append(
+                    f"{MAKE_AUTHORITY_PLAN.relative_to(ROOT)} must record verification evidence {evidence!r}"
+                )
+        if str(MAKE_AUTHORITY_PLAN.relative_to(ROOT)) not in read_text("README.md"):
+            errors.append(f"README.md must reference {MAKE_AUTHORITY_PLAN.relative_to(ROOT)}")
 
     for doc_path in ("README.md", "VISION.md", "SECURITY.md", "CHANGES.md"):
         document = re.sub(r"\s+", " ", read_text(doc_path))

--- a/scripts/run-python.sh
+++ b/scripts/run-python.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+exec /usr/bin/python3 -I -B -c 'import os, runpy, sys; script = sys.argv[1]; sys.argv = sys.argv[1:]; sys.path.insert(0, os.path.dirname(os.path.realpath(script))); runpy.run_path(script, run_name="__main__")' "$@"

--- a/scripts/run-xcodebuild.sh
+++ b/scripts/run-xcodebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+exec /usr/bin/xcodebuild "$@"

--- a/scripts/test-makefile-root.sh
+++ b/scripts/test-makefile-root.sh
@@ -176,11 +176,20 @@ grep -Fq "MAKEFILE_LIST must not be overridden" "$TEMP_ROOT/command-list.out"
 if (cd "$CONTROL_DIR" && MAKEFILE_LIST=/tmp/untrusted /usr/bin/make --environment-overrides --no-print-directory --file "$MAKEFILE" check) >"$TEMP_ROOT/environment-list.out" 2>&1; then exit 1; fi
 grep -Fq "MAKEFILE_LIST must not be overridden" "$TEMP_ROOT/environment-list.out"
 PRELOADED="$TEMP_ROOT/preloaded.mk"
-printf '%s\n' 'ROOT := /tmp/preloaded' >"$PRELOADED"
+PRELOAD_MARKER="$TEMP_ROOT/preload-startup-ran"
+printf '%s\n' "\$(shell /usr/bin/touch '$PRELOAD_MARKER')" 'ROOT := /tmp/preloaded' >"$PRELOADED"
 if (cd "$CONTROL_DIR" && MAKEFILES="$PRELOADED" /usr/bin/make --no-print-directory --file "$MAKEFILE" check) >"$TEMP_ROOT/preloaded.out" 2>&1; then exit 1; fi
 grep -Fq "MAKEFILES must be empty" "$TEMP_ROOT/preloaded.out"
+[ -e "$PRELOAD_MARKER" ]
 EARLIER="$TEMP_ROOT/earlier.mk"
-printf '%s\n' '# earlier' >"$EARLIER"
+EARLIER_MARKER="$TEMP_ROOT/earlier-startup-ran"
+printf '%s\n' "\$(shell /usr/bin/touch '$EARLIER_MARKER')" >"$EARLIER"
 if (cd "$CONTROL_DIR" && /usr/bin/make --no-print-directory --file "$EARLIER" --file "$MAKEFILE" check) >"$TEMP_ROOT/multiple.out" 2>&1; then exit 1; fi
 grep -Fq "repository Makefile path could not be resolved" "$TEMP_ROOT/multiple.out"
-printf '%s\n' "Makefile root tests passed: 66 executed target/authority cases, 1 dollar-syntax checkout case, 2 MAKEFILE_LIST rejections, 1 MAKEFILES rejection, and 1 earlier-Makefile detection"
+[ -e "$EARLIER_MARKER" ]
+LATER="$TEMP_ROOT/later.mk"
+LATER_MARKER="$TEMP_ROOT/later-startup-ran"
+printf '%s\n' "\$(shell /usr/bin/touch '$LATER_MARKER')" >"$LATER"
+(cd "$CONTROL_DIR" && SCREENSHARE_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" --file "$LATER" lint) >"$TEMP_ROOT/later.out" 2>&1
+[ -e "$LATER_MARKER" ]
+printf '%s\n' "Makefile root tests passed: 66 executed target/authority cases, 1 dollar-syntax checkout case, 2 MAKEFILE_LIST rejections, and 3 documented GNU Make startup-boundary cases"

--- a/scripts/test-makefile-root.sh
+++ b/scripts/test-makefile-root.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && /bin/pwd -P)
+TEMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/screenshare-root-control-XXXXXX")
+ATTACKER_ROOT="$TEMP_ROOT/attacker-root"
+trap 'rm -rf "$TEMP_ROOT"' EXIT HUP INT TERM
+unset MAKEFILES MAKEFILE_LIST MAKEFLAGS MFLAGS MAKEOVERRIDES ROOT PYTHON XCODEBUILD PYTHONDONTWRITEBYTECODE
+
+CONTROL_DIR="$TEMP_ROOT/control"
+CHECKOUT="$TEMP_ROOT/screenshare's [gate] \"quoted\" \`touch SCREENSHARE_BACKTICK_MARKER\`"
+COMMAND_LOG="$TEMP_ROOT/commands.log"
+BAD_COMMAND_LOG="$TEMP_ROOT/bad-command.log"
+FAKE_SHELL_LOG="$TEMP_ROOT/fake-shell.log"
+mkdir "$CONTROL_DIR" "$CHECKOUT" "$CHECKOUT/scripts" "$CHECKOUT/bin" "$ATTACKER_ROOT"
+CONTROL_DIR=$(CDPATH= cd -- "$CONTROL_DIR" && /bin/pwd -P)
+CHECKOUT=$(CDPATH= cd -- "$CHECKOUT" && /bin/pwd -P)
+MAKEFILE="$CHECKOUT/Makefile"
+cp "$ROOT_DIR/Makefile" "$MAKEFILE"
+printf '%s\n' '#!/bin/sh' 'exit 0' >"$CHECKOUT/build.sh"
+chmod +x "$CHECKOUT/build.sh"
+
+for command in python3 xcodebuild; do
+  cat >"$CHECKOUT/bin/$command" <<'EOF'
+#!/bin/sh
+printf '%s|%s|%s|%s\n' "$PWD" "$0" "${PYTHONDONTWRITEBYTECODE:-}" "$*" >> "$SCREENSHARE_COMMAND_LOG"
+EOF
+  chmod +x "$CHECKOUT/bin/$command"
+done
+cat >"$CHECKOUT/scripts/test-makefile-root.sh" <<'EOF'
+#!/bin/sh
+printf '%s|%s|%s|root-test\n' "$PWD" "$0" "${PYTHONDONTWRITEBYTECODE:-}" >> "$SCREENSHARE_COMMAND_LOG"
+EOF
+chmod +x "$CHECKOUT/scripts/test-makefile-root.sh"
+
+BAD_COMMAND="$TEMP_ROOT/bad-command"
+cat >"$BAD_COMMAND" <<EOF
+#!/bin/sh
+printf '%s\n' invoked >> '$BAD_COMMAND_LOG'
+exit 91
+EOF
+chmod +x "$BAD_COMMAND"
+
+FAKE_SHELL="$TEMP_ROOT/fake-shell"
+cat >"$FAKE_SHELL" <<EOF
+#!/bin/sh
+printf '%s\n' invoked >> '$FAKE_SHELL_LOG'
+exec /bin/sh "\$@"
+EOF
+chmod +x "$FAKE_SHELL"
+
+assert_commands_stayed_in_checkout() {
+  scenario=$1
+  target=$2
+  if [ ! -s "$COMMAND_LOG" ]; then
+    printf '%s\n' "$scenario $target executed no quality command" >&2
+    exit 1
+  fi
+  while IFS= read -r command; do
+    case "$command" in
+      "$CONTROL_DIR|"*"$CHECKOUT"*"|1|"*) ;;
+      "$CHECKOUT|"*"|1|"*) ;;
+      *)
+        printf '%s\n' "$scenario $target escaped the checkout or enabled bytecode: $command" >&2
+        exit 1
+        ;;
+    esac
+  done <"$COMMAND_LOG"
+}
+
+run_case() {
+  scenario=$1
+  target=$2
+  mode=$3
+  rm -f "$COMMAND_LOG" "$BAD_COMMAND_LOG" "$FAKE_SHELL_LOG"
+  output="$TEMP_ROOT/output"
+  set +e
+  case "$mode" in
+    default)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SCREENSHARE_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "$target") >"$output" 2>&1 ;;
+    command-root)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SCREENSHARE_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "ROOT=$ATTACKER_ROOT" "$target") >"$output" 2>&1 ;;
+    environment-root)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" ROOT="$ATTACKER_ROOT" SCREENSHARE_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "$target") >"$output" 2>&1 ;;
+    command-shell)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SCREENSHARE_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "SHELL=$FAKE_SHELL" "$target") >"$output" 2>&1 ;;
+    environment-shell)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SHELL="$FAKE_SHELL" SCREENSHARE_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "$target") >"$output" 2>&1 ;;
+    command-flags)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SCREENSHARE_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" '.SHELLFLAGS=-eu -c' "$target") >"$output" 2>&1 ;;
+    environment-flags)
+      (cd "$CONTROL_DIR" && env '.SHELLFLAGS=-eu -c' PATH="$CHECKOUT/bin:$PATH" SCREENSHARE_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "$target") >"$output" 2>&1 ;;
+    command-python)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SCREENSHARE_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "PYTHON=$BAD_COMMAND" "$target") >"$output" 2>&1 ;;
+    environment-python)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" PYTHON="$BAD_COMMAND" SCREENSHARE_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "$target") >"$output" 2>&1 ;;
+    command-xcodebuild)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" SCREENSHARE_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "XCODEBUILD=$BAD_COMMAND" "$target") >"$output" 2>&1 ;;
+    environment-xcodebuild)
+      (cd "$CONTROL_DIR" && PATH="$CHECKOUT/bin:$PATH" XCODEBUILD="$BAD_COMMAND" SCREENSHARE_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory --file "$MAKEFILE" "$target") >"$output" 2>&1 ;;
+    *)
+      printf '%s\n' "unknown test mode: $mode" >&2
+      exit 1 ;;
+  esac
+  result=$?
+  set -e
+  if [ "$result" -ne 0 ]; then
+    printf '%s\n' "$scenario $target failed" >&2
+    cat "$output" >&2
+    exit 1
+  fi
+  assert_commands_stayed_in_checkout "$scenario" "$target"
+  if [ -e "$BAD_COMMAND_LOG" ]; then
+    printf '%s\n' "$scenario $target executed caller-controlled Python or xcodebuild" >&2
+    exit 1
+  fi
+  if [ -e "$FAKE_SHELL_LOG" ]; then
+    printf '%s\n' "$scenario $target executed caller-controlled shell" >&2
+    exit 1
+  fi
+}
+
+for target in build check lint root-test test verify; do
+  run_case default "$target" default
+  run_case command-root "$target" command-root
+  run_case environment-root "$target" environment-root
+  run_case command-shell "$target" command-shell
+  run_case environment-shell "$target" environment-shell
+  run_case command-flags "$target" command-flags
+  run_case environment-flags "$target" environment-flags
+  run_case command-python "$target" command-python
+  run_case environment-python "$target" environment-python
+  run_case command-xcodebuild "$target" command-xcodebuild
+  run_case environment-xcodebuild "$target" environment-xcodebuild
+done
+
+if [ -e "$CONTROL_DIR/SCREENSHARE_BACKTICK_MARKER" ]; then
+  printf '%s\n' "checkout path executed a command substitution" >&2
+  exit 1
+fi
+
+if (cd "$CONTROL_DIR" && /usr/bin/make --no-print-directory --file "$MAKEFILE" MAKEFILE_LIST=/tmp/untrusted check) >"$TEMP_ROOT/command-list.out" 2>&1; then exit 1; fi
+grep -Fq "MAKEFILE_LIST must not be overridden" "$TEMP_ROOT/command-list.out"
+if (cd "$CONTROL_DIR" && MAKEFILE_LIST=/tmp/untrusted /usr/bin/make --environment-overrides --no-print-directory --file "$MAKEFILE" check) >"$TEMP_ROOT/environment-list.out" 2>&1; then exit 1; fi
+grep -Fq "MAKEFILE_LIST must not be overridden" "$TEMP_ROOT/environment-list.out"
+PRELOADED="$TEMP_ROOT/preloaded.mk"
+printf '%s\n' 'ROOT := /tmp/preloaded' >"$PRELOADED"
+if (cd "$CONTROL_DIR" && MAKEFILES="$PRELOADED" /usr/bin/make --no-print-directory --file "$MAKEFILE" check) >"$TEMP_ROOT/preloaded.out" 2>&1; then exit 1; fi
+grep -Fq "MAKEFILES must be empty" "$TEMP_ROOT/preloaded.out"
+EARLIER="$TEMP_ROOT/earlier.mk"
+printf '%s\n' '# earlier' >"$EARLIER"
+if (cd "$CONTROL_DIR" && /usr/bin/make --no-print-directory --file "$EARLIER" --file "$MAKEFILE" check) >"$TEMP_ROOT/multiple.out" 2>&1; then exit 1; fi
+grep -Fq "repository Makefile path could not be resolved" "$TEMP_ROOT/multiple.out"
+printf '%s\n' "Makefile root tests passed: 66 executed target/authority cases, 2 MAKEFILE_LIST rejections, 1 MAKEFILES rejection, and 1 multi-Makefile rejection"

--- a/scripts/test-makefile-root.sh
+++ b/scripts/test-makefile-root.sh
@@ -12,6 +12,8 @@ CHECKOUT="$TEMP_ROOT/screenshare's [gate] \"quoted\" \`touch SCREENSHARE_BACKTIC
 COMMAND_LOG="$TEMP_ROOT/commands.log"
 BAD_COMMAND_LOG="$TEMP_ROOT/bad-command.log"
 FAKE_SHELL_LOG="$TEMP_ROOT/fake-shell.log"
+PATH_SHADOW_LOG="$TEMP_ROOT/path-shadow.log"
+export SCREENSHARE_PATH_SHADOW_LOG="$PATH_SHADOW_LOG"
 mkdir "$CONTROL_DIR" "$CHECKOUT" "$CHECKOUT/scripts" "$CHECKOUT/bin" "$ATTACKER_ROOT"
 CONTROL_DIR=$(CDPATH= cd -- "$CONTROL_DIR" && /bin/pwd -P)
 CHECKOUT=$(CDPATH= cd -- "$CHECKOUT" && /bin/pwd -P)
@@ -23,9 +25,16 @@ chmod +x "$CHECKOUT/build.sh"
 for command in python3 xcodebuild; do
   cat >"$CHECKOUT/bin/$command" <<'EOF'
 #!/bin/sh
-printf '%s|%s|%s|%s\n' "$PWD" "$0" "${PYTHONDONTWRITEBYTECODE:-}" "$*" >> "$SCREENSHARE_COMMAND_LOG"
+printf '%s\n' invoked >> "$SCREENSHARE_PATH_SHADOW_LOG"
 EOF
   chmod +x "$CHECKOUT/bin/$command"
+done
+for command in run-python.sh run-xcodebuild.sh; do
+  cat >"$CHECKOUT/scripts/$command" <<'EOF'
+#!/bin/sh
+printf '%s|%s|%s|%s\n' "$PWD" "$0" "${PYTHONDONTWRITEBYTECODE:-}" "$*" >> "$SCREENSHARE_COMMAND_LOG"
+EOF
+  chmod +x "$CHECKOUT/scripts/$command"
 done
 cat >"$CHECKOUT/scripts/test-makefile-root.sh" <<'EOF'
 #!/bin/sh
@@ -72,7 +81,7 @@ run_case() {
   scenario=$1
   target=$2
   mode=$3
-  rm -f "$COMMAND_LOG" "$BAD_COMMAND_LOG" "$FAKE_SHELL_LOG"
+  rm -f "$COMMAND_LOG" "$BAD_COMMAND_LOG" "$FAKE_SHELL_LOG" "$PATH_SHADOW_LOG"
   output="$TEMP_ROOT/output"
   set +e
   case "$mode" in
@@ -118,6 +127,10 @@ run_case() {
     printf '%s\n' "$scenario $target executed caller-controlled shell" >&2
     exit 1
   fi
+  if [ -e "$PATH_SHADOW_LOG" ]; then
+    printf '%s\n' "$scenario $target executed a PATH-shadowed Python or xcodebuild" >&2
+    exit 1
+  fi
 }
 
 for target in build check lint root-test test verify; do
@@ -133,6 +146,25 @@ for target in build check lint root-test test verify; do
   run_case command-xcodebuild "$target" command-xcodebuild
   run_case environment-xcodebuild "$target" environment-xcodebuild
 done
+
+DOLLAR_CHECKOUT="$TEMP_ROOT/screenshare \$(touch SCREENSHARE_DOLLAR_MARKER)"
+mkdir "$DOLLAR_CHECKOUT" "$DOLLAR_CHECKOUT/scripts"
+DOLLAR_CHECKOUT=$(CDPATH= cd -- "$DOLLAR_CHECKOUT" && /bin/pwd -P)
+cp "$MAKEFILE" "$DOLLAR_CHECKOUT/Makefile"
+cp "$CHECKOUT/build.sh" "$DOLLAR_CHECKOUT/build.sh"
+cp "$CHECKOUT/scripts/run-python.sh" "$DOLLAR_CHECKOUT/scripts/run-python.sh"
+rm -f "$COMMAND_LOG" "$PATH_SHADOW_LOG"
+(cd "$DOLLAR_CHECKOUT" && PATH="$CHECKOUT/bin:$PATH" SCREENSHARE_COMMAND_LOG="$COMMAND_LOG" /usr/bin/make --no-print-directory lint) >"$TEMP_ROOT/dollar-path.out" 2>&1
+case "$(cat "$COMMAND_LOG")" in
+  "$DOLLAR_CHECKOUT|$DOLLAR_CHECKOUT/scripts/run-python.sh|1|"*) ;;
+  *)
+    printf '%s\n' "dollar-syntax checkout escaped repository-owned Python: $(cat "$COMMAND_LOG")" >&2
+    exit 1 ;;
+esac
+if [ -e "$DOLLAR_CHECKOUT/SCREENSHARE_DOLLAR_MARKER" ] || [ -e "$PATH_SHADOW_LOG" ]; then
+  printf '%s\n' "dollar-syntax checkout executed command syntax or a PATH-shadowed tool" >&2
+  exit 1
+fi
 
 if [ -e "$CONTROL_DIR/SCREENSHARE_BACKTICK_MARKER" ]; then
   printf '%s\n' "checkout path executed a command substitution" >&2
@@ -151,4 +183,4 @@ EARLIER="$TEMP_ROOT/earlier.mk"
 printf '%s\n' '# earlier' >"$EARLIER"
 if (cd "$CONTROL_DIR" && /usr/bin/make --no-print-directory --file "$EARLIER" --file "$MAKEFILE" check) >"$TEMP_ROOT/multiple.out" 2>&1; then exit 1; fi
 grep -Fq "repository Makefile path could not be resolved" "$TEMP_ROOT/multiple.out"
-printf '%s\n' "Makefile root tests passed: 66 executed target/authority cases, 2 MAKEFILE_LIST rejections, 1 MAKEFILES rejection, and 1 multi-Makefile rejection"
+printf '%s\n' "Makefile root tests passed: 66 executed target/authority cases, 1 dollar-syntax checkout case, 2 MAKEFILE_LIST rejections, 1 MAKEFILES rejection, and 1 earlier-Makefile detection"

--- a/scripts/test-screenshare-contracts.py
+++ b/scripts/test-screenshare-contracts.py
@@ -25,7 +25,12 @@ class ContractMutationTests(unittest.TestCase):
 
     def assert_behavior_rejects(self, repository, expected_error):
         result = subprocess.run(
-            ["python3", "scripts/check-screenshare-source.py", "--mode", "behavior"],
+            [
+                str(repository / "scripts/run-python.sh"),
+                "scripts/check-screenshare-source.py",
+                "--mode",
+                "behavior",
+            ],
             cwd=repository,
             text=True,
             capture_output=True,
@@ -107,7 +112,12 @@ class ContractMutationTests(unittest.TestCase):
             "PRODUCT_MODULE_NAME = Screenshare;",
         )
         result = subprocess.run(
-            ["python3", "scripts/check-screenshare-source.py", "--mode", "project"],
+            [
+                str(repository / "scripts/run-python.sh"),
+                "scripts/check-screenshare-source.py",
+                "--mode",
+                "project",
+            ],
             cwd=repository,
             text=True,
             capture_output=True,
@@ -125,7 +135,12 @@ class ContractMutationTests(unittest.TestCase):
             "self.measureBlock() {",
         )
         result = subprocess.run(
-            ["python3", "scripts/check-screenshare-source.py", "--mode", "project"],
+            [
+                str(repository / "scripts/run-python.sh"),
+                "scripts/check-screenshare-source.py",
+                "--mode",
+                "project",
+            ],
             cwd=repository,
             text=True,
             capture_output=True,


### PR DESCRIPTION
## Summary
ScreenShare’s repository validation now keeps its checked-in recipes and tool launchers authoritative after GNU Make has loaded the intended Makefile. Hostile variable overrides and `PATH` entries can no longer redirect the project checks, contract mutations, or Xcode build command.

## Baseline
- The earlier Make contract rejected caller-supplied roots, shells, and tool variables but still resolved Python and Xcode through `PATH`.
- Contract mutation tests also invoked `python3` directly, leaving a second untrusted tool-resolution path.
- The prior documentation overstated what a checked-in Makefile can prevent: preload files and earlier or later `-f` files execute during GNU Make startup before recipe-level validation can stop them.

## Improvements
- **Build security:** Route verification through repository-owned launchers that call `/usr/bin/python3` and `/usr/bin/xcodebuild` directly; use the absolute Xcode path in `build.sh` and CI diagnostics.
- **Regression testing:** Cover all six public targets across 66 authority cases, a literal-dollar checkout path, two metadata rejections, and three explicit GNU Make startup-boundary cases.
- **Contract integrity:** Run mutation tests through the isolated Python launcher and make the source checker enforce every trusted-launcher path.
- **Operational clarity:** Document the boundary between checked-in recipe authority and startup files that GNU Make has already evaluated.

## Validation
- `make root-test` — passed: 66 target/authority cases, one literal-dollar checkout case, two metadata rejections, and three documented startup-boundary cases.
- `make check` — passed at exact head `9a157e2580f9df1abfe349347422e3b36554c4e7`: project checks, behavior checks, and 7 contract mutation tests.
- External-directory `make check` through the absolute Makefile path — passed.
- Hostile-`PATH` `make lint` and `make build` — passed without invoking replacement `python3` or `xcodebuild` executables.
- Shell/Python syntax, `git diff --check`, `git fsck --strict`, and Gitleaks across `master..9a157e2580f9df1abfe349347422e3b36554c4e7` — passed.
- Open Dependabot, code-scanning, and secret-scanning alerts — 0 / 0 / 0.
- Registered worktrees — unchanged: 7 worktrees, 809 entries, canonical state fingerprint `41fa8a74192781be30454b69d830fb68ad78a78939c3b3a1bc25b03a5d489b89` before and after.
- Hosted exact-head `contract`, `build`, Actions CodeQL, Python CodeQL, and Swift CodeQL jobs — all completed successfully; the aggregate CodeQL status is neutral as emitted by GitHub.

## Risk
- A Makefile cannot undo side effects from `MAKEFILES` preloads or additional `-f` files already evaluated during GNU Make startup; the tests now demonstrate and document that boundary rather than claiming prevention.
- The launcher policy intentionally relies on Apple/Linux system tool paths instead of caller-selected toolchains.
- Physical iOS mirroring, capture permissions, signing, and interactive application behavior were not exercised on the Linux host.

## Follow-Ups
- Keep the exact-head hosted build and CodeQL gates required before merge.
- Perform physical-device mirroring and permission-flow smoke testing when compatible Apple hardware is available.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/gpt--5.4-000000)


