### PR TITLE
Document ScreenShare device setup and lifecycle

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,36 @@
 # Changes
 
+## 2026-06-26
+
+### ScreenShare device setup and lifecycle guide
+
+- Completed three ScreenShare device-documentation priorities with source-backed
+  macOS/Xcode setup, camera permission, CoreMediaIO device registration,
+  single-session admission, connect/disconnect, local-data, and verification
+  guidance.
+- Added fail-closed documentation contracts and a completed implementation plan
+  so future edits cannot silently remove the operating boundaries.
+
+Validation:
+
+- Rejected 19 isolated hostile documentation mutations spanning every new
+  README contract, the maintained roadmap boundary, this history entry, and the
+  completed plan status.
+- Passed `/usr/bin/make check` from the checkout and from an unrelated working
+  directory. Each invocation passed 66 Make target/authority cases, one dollar-
+  syntax checkout case, two `MAKEFILE_LIST` rejections, three documented GNU
+  Make startup-boundary cases, project checks, behavior checks, and seven Python
+  contract tests.
+- Audited the guide against the checked-in entitlement and usage plist, Swift
+  registration/filter/session/notification/archive code, Xcode deployment
+  settings, and pinned Ubuntu/macOS workflow jobs.
+
+Blocker:
+
+- Physical-device trust, Camera authorization, live mirroring, disconnect, and
+  reconnect verification still require an unlocked iPhone or iPad and cannot be
+  demonstrated by the current Linux checkout or hosted native build alone.
+
 ## 2026-06-21
 
 - Isolated checked-in Make recipes from caller-controlled shells, Python

--- a/README.md
+++ b/README.md
@@ -39,21 +39,66 @@ Additional scan context:
 
 ## Getting Started
 
-### Prerequisites
+### Supported macOS Baseline
 
 - Git
-- macOS with Xcode for building Apple platform projects
+- macOS with Xcode for building the AppKit application
 - Python 3 for repository source checks
-- An unlocked iPhone or iPad connected to the Mac over USB for live mirroring
+- Swift 5 with a macOS 10.13 deployment target, as pinned in the project
+- An unlocked, trusted iPhone or iPad connected to the Mac over USB for live
+  mirroring
 
 ### Setup
 
 ```bash
 git clone https://github.com/garethpaul/ScreenShare.git
 cd ScreenShare
+open Screenshare.xcodeproj
 ```
 
-The setup commands above are derived from repository files. Legacy mobile, Python, or JavaScript samples may require older SDKs or package versions than a modern workstation uses by default.
+Select the shared `Screenshare` scheme and the `My Mac` destination. Command-line
+verification disables code signing; an interactive run may require a local
+development team under the workstation's signing policy.
+
+### Camera Permission Boundary
+
+The app sandbox includes the sandbox camera entitlement. `Info.plist` declares
+the exact usage text: `ScreenShare uses camera access to display connected iOS devices as demo capture sources.`
+macOS may therefore ask for Camera permission. Denying that permission or
+disabling it later prevents capture input from being admitted; ScreenShare does
+not need Photos, microphone, screen-recording, network, or location permission.
+
+### Connected iOS Device Registration
+
+At launch, `DeviceUtils.registerForScreenCaptureDevices()` enables CoreMediaIO
+property `kCMIOHardwarePropertyAllowScreenCaptureDevices`. The app then scans
+AVFoundation muxed and video devices and admits connected hardware whose
+model ID is `iOS Device`. Keep the iPhone or iPad unlocked, trust the Mac when
+prompted by the device, and confirm macOS can see it before troubleshooting the
+app.
+
+### One-Device Session Limit
+
+The current app supports one active mirrored device. If a second eligible
+device appears while a session is active, ScreenShare presents `Only one device
+supported` and asks the user to disconnect the other device. This is an
+intentional admission boundary, not multi-device arbitration.
+
+### Connect and Disconnect Behavior
+
+ScreenShare observes `AVCaptureDevice.wasConnectedNotification` and
+`AVCaptureDevice.wasDisconnectedNotification`, refreshes the device list on the
+main queue, creates a window only after input and window attachment succeed,
+and ends/closes a session when its device disappears. Reconnect and unlock the
+device if it does not reappear; restart the app only after macOS itself sees the
+device.
+
+### Local Data Boundary
+
+ScreenShare saves only local device identity/orientation/window geometry needed
+to restore framing. It does not record mirrored video, upload frames, enumerate
+user media, or persist a capture stream. Device names and saved rectangles are
+excluded from debug logging by static contracts.
 
 ## Running or Using the Project
 
@@ -69,6 +114,14 @@ the app. Signing is disabled for the command-line gate, but interactive Xcode
 runs may still require a local development team depending on workstation policy.
 
 ## Testing and Verification
+
+### Canonical Verification
+
+Run:
+
+```sh
+/usr/bin/make check
+```
 
 - `make check` runs shell syntax checks, static Xcode project checks, and
   capture permission/runtime-error metadata checks. When `xcodebuild` is
@@ -100,6 +153,14 @@ runs may still require a local development team depending on workstation policy.
   replacement cannot be constructed or admitted.
 - Initial Skin sessions reject unattached capture devices before window and
   view attachment.
+
+### Hosted Native Verification
+
+GitHub Actions runs the portable contract gate on Ubuntu 24.04 and builds the
+unsigned `Screenshare` scheme on `macos-15`. Hosted build success proves source
+and project compatibility; it does not prove a physical iOS device was trusted,
+connected, authorized, mirrored, disconnected, and reconnected. Use the manual
+steps above for that hardware boundary.
 - Static behavior checks also require document preview setup and aspect updates
   to optional-bind outlets, backing layers, input ports, and windows.
 - Skin preview and window guards optional-bind preview layers and resize-window

--- a/VISION.md
+++ b/VISION.md
@@ -47,13 +47,12 @@ Priority:
 - Maintain custom skin and screenshot context
 - Keep completed maintenance plans under `docs/plans`
 - Keep GitHub Actions running static checks and an unsigned macOS app build
+- Keep macOS setup, camera permission, device registration, and
+  connect/disconnect guidance synchronized with source
 - Avoid recording, uploading, or storing mirrored content by default
 
 Next priorities:
 
-- Add setup notes for macOS, Xcode, and connected iOS devices
-- Document permissions and device registration behavior
-- Add manual verification notes for connect/disconnect handling
 - Continue reducing legacy force unwraps in skin/window sizing paths
 - Modernize Swift and project settings in a dedicated pass
 

--- a/docs/plans/2026-06-26-screenshare-device-guide.md
+++ b/docs/plans/2026-06-26-screenshare-device-guide.md
@@ -1,0 +1,104 @@
+# ScreenShare Device Setup Guide Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use executing-plans to implement this plan task-by-task.
+
+**Goal:** Document ScreenShare's supported macOS setup, camera permission, connected-iOS device registration, one-device limit, and connect/disconnect behavior from checked-in source.
+
+**Architecture:** Preserve the Swift 5/macOS 10.13 app, CoreMediaIO opt-in, AVFoundation notifications, session logic, tests, workflow, and project settings. Add fail-closed contracts for setup and device-operation guidance, then retire only the three completed documentation roadmap items.
+
+**Tech Stack:** Markdown, Python 3 static contracts, Swift 5/AppKit/AVFoundation/CoreMediaIO, GNU Make, Xcode, GitHub Actions
+
+---
+
+## Status: Completed
+
+### Task 1: Add The Documentation Contract
+
+**Files:**
+- Modify: `scripts/check-screenshare-source.py`
+- Test: `scripts/check-screenshare-source.py`
+
+**Step 1: Write the failing test**
+
+Require supported baseline, setup, permission, device registration, one-device, connect/disconnect, verification, roadmap, history, and completed-plan guidance.
+
+**Step 2: Run test to verify it fails**
+
+Run: `python3 scripts/check-screenshare-source.py --mode project`
+
+Expected: FAIL because current guidance does not separate these operating boundaries.
+
+### Task 2: Write The Device Guide
+
+**Files:**
+- Modify: `README.md`
+- Modify: `VISION.md`
+- Modify: `CHANGES.md`
+
+**Step 1: Write minimal documentation**
+
+Document Swift 5/macOS 10.13, Xcode project setup, sandbox camera entitlement and usage text, CoreMediaIO opt-in, unlocked/trusted USB device discovery, `iOS Device` filtering, one-session admission, automatic connect/disconnect refresh, local settings, and portable/native verification.
+
+**Step 2: Run focused contracts**
+
+Run: `python3 scripts/check-screenshare-source.py --mode project`
+
+Expected: PASS.
+
+### Task 3: Prove Drift Fails Closed
+
+**Files:**
+- Test: `scripts/check-screenshare-source.py`
+
+**Step 1: Apply hostile mutations**
+
+Mutate project versions, permission, registration, device identity, one-device limit, connect/disconnect behavior, local-data boundary, verification, roadmap, history, and plan status.
+
+**Step 2: Verify each mutation fails**
+
+Run the project checker after each mutation.
+
+Expected: every mutation is rejected.
+
+### Task 4: Run The Full Gate
+
+**Files:**
+- Verify: `Makefile`
+
+**Step 1: Run repository and external gates**
+
+Run: `/usr/bin/make check`
+
+Run: `cd "$(mktemp -d)" && /usr/bin/make -f /absolute/path/to/Makefile check`
+
+Expected: portable project/behavior/mutation/Make authority gates pass; hosted macOS supplies the unsigned native build.
+
+### Task 5: Commit And Ship
+
+**Files:**
+- Modify: `CHANGES.md`
+- Modify: `docs/plans/2026-06-26-screenshare-device-guide.md`
+
+**Step 1: Record exact validation**
+
+Add mutation, local gate, hosted build, review, and blocker evidence.
+
+**Step 2: Commit**
+
+```bash
+git add README.md VISION.md CHANGES.md scripts/check-screenshare-source.py docs/plans/2026-06-26-screenshare-device-guide.md
+git commit -m "docs: document ScreenShare device setup"
+```
+
+## Results
+
+- The focused project checker passed after the expected documentation-contract
+  failure and the guide update.
+- All 19 isolated hostile documentation mutations were rejected.
+- `/usr/bin/make check` passed from the checkout and an unrelated working
+  directory, including 66 Make target/authority cases and seven Python contract
+  tests per invocation.
+- Source claims were audited against the entitlement and usage plists, Swift
+  lifecycle code, Xcode settings, and the pinned Ubuntu/macOS workflow.
+- Live trust, authorization, mirroring, disconnect, and reconnect verification
+  remains a physical-device boundary.

--- a/scripts/check-screenshare-source.py
+++ b/scripts/check-screenshare-source.py
@@ -21,6 +21,7 @@ SKIN_POINTER_WINDOW_PLAN = DOCS_PLANS / "2026-06-15-skin-pointer-window-guards.m
 SESSION_REGISTRATION_PLAN = DOCS_PLANS / "2026-06-15-session-registration-guard.md"
 SKIN_DEVICE_SWITCH_PLAN = DOCS_PLANS / "2026-06-16-skin-device-switch-rollback.md"
 INITIAL_SKIN_ATTACHMENT_PLAN = DOCS_PLANS / "2026-06-17-initial-skin-device-attachment-guard.md"
+DEVICE_GUIDE_PLAN = DOCS_PLANS / "2026-06-26-screenshare-device-guide.md"
 EXPECTED_WORKFLOW = """name: Check
 
 on:
@@ -103,6 +104,39 @@ def require_paths():
 
 def docs_plan_checks():
     errors = []
+    normalized_readme = " ".join(read_text("README.md").split())
+    for contract in (
+        "Supported macOS Baseline",
+        "Swift 5 with a macOS 10.13 deployment target",
+        "Camera Permission Boundary",
+        "sandbox camera entitlement",
+        "ScreenShare uses camera access to display connected iOS devices as demo capture sources.",
+        "Connected iOS Device Registration",
+        "kCMIOHardwarePropertyAllowScreenCaptureDevices",
+        "model ID is `iOS Device`",
+        "One-Device Session Limit",
+        "Connect and Disconnect Behavior",
+        "AVCaptureDevice.wasConnectedNotification",
+        "AVCaptureDevice.wasDisconnectedNotification",
+        "Local Data Boundary",
+        "Canonical Verification",
+        "/usr/bin/make check",
+        "Hosted Native Verification",
+    ):
+        if contract not in normalized_readme:
+            errors.append(f"README device guide must preserve: {contract}")
+    normalized_vision = " ".join(read_text("VISION.md").split())
+    normalized_changes = " ".join(read_text("CHANGES.md").split())
+    if "Keep macOS setup, camera permission, device registration, and connect/disconnect guidance synchronized with source" not in normalized_vision:
+        errors.append("VISION must preserve the ScreenShare device-guide boundary")
+    if "Completed three ScreenShare device-documentation priorities" not in normalized_changes:
+        errors.append("CHANGES must record the ScreenShare device-guide reconciliation")
+    if not DEVICE_GUIDE_PLAN.exists():
+        errors.append("ScreenShare device guide plan is missing")
+    else:
+        plan = DEVICE_GUIDE_PLAN.read_text(encoding="utf-8")
+        if "## Status: Completed" not in plan or "Document ScreenShare's supported macOS setup" not in plan:
+            errors.append("ScreenShare device guide plan must record completed evidence")
     if not CANONICAL_PLAN.exists():
         errors.append("docs/plans/2026-06-08-screenshare-baseline.md is missing")
     if not DOCUMENT_PREVIEW_PLAN.exists():


### PR DESCRIPTION
## Summary

- Document the supported Swift 5/macOS 10.13 Xcode setup and unsigned verification path.
- Explain the sandbox Camera permission, CoreMediaIO registration, iOS-device filter, and one-session limit.
- Document connect/disconnect behavior, local-data boundaries, and the physical-device verification gap.
- Add fail-closed documentation contracts and retire the completed roadmap items.

## Baseline

The sample lacked one canonical device setup and lifecycle guide connecting its Xcode settings and entitlements to Camera authorization, CoreMediaIO device discovery, session limits, local archives, and manual hardware verification.

## Improvements

- **Documentation:** Added the legacy Xcode/macOS baseline, unsigned path, permission flow, device lifecycle, and local-data boundaries.
- **Tests:** Added mutation-sensitive documentation and source-claim contracts.
- **Security:** Clarified Camera permission and local-only archive behavior.
- **Developer experience:** Added exact project, scheme, and physical-device setup guidance.

## Validation

- `python3 scripts/check-screenshare-source.py --mode project` passed.
- Nineteen isolated hostile documentation mutations were rejected.
- `/usr/bin/make check` passed from the checkout and an unrelated working directory.
- Each full invocation passed 66 Make authority cases and seven Python contract tests.
- Source claims were audited against entitlements, `Info.plist`, Swift lifecycle code, Xcode settings, and pinned workflow jobs.

## Risk

The guide enforces existing behavior but does not prove hardware interaction. A physical unlocked and trusted iPhone or iPad is still required to verify Camera authorization, live mirroring, disconnect, and reconnect behavior.

## Follow-Ups

Run the documented physical-device matrix with synthetic non-sensitive content and retain privacy-safe evidence.
