### PR TITLE
Observe document input format changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,9 @@
   replacement cannot be constructed or admitted.
 - Initial Skin sessions reject unattached capture devices before window and
   view attachment.
+- Document aspect updates run once after session start and then only for the
+  active input port's format-change notifications; device switches replace the
+  observer and window teardown removes it.
 - See `docs/plans/2026-06-08-device-archive-decoding.md` for the local device-settings archive guard.
 
 ## Agent workflow

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,66 @@
 # Changes
 
+## 2026-06-26 06:52 PDT - P2 - replace document aspect polling
+
+### Summary
+
+Replaced the document preview's repeating one-second aspect timer with the
+active capture input port's format-change notification, preserving an immediate
+refresh after session start and safe observer replacement during device swaps.
+
+### Work completed
+
+- Added a dedicated document format-observer owner that follows the existing
+  Skin lifecycle precedent.
+- Document aspect updates run once after session start and then only for the
+  active input port's format-change notifications; device switches replace the
+  observer and window teardown removes it.
+- Replaced observers after successful, cleared, and rolled-back device
+  transactions and removed them during window teardown.
+- Added scoped source contracts, three hostile mutations, design evidence, and a
+  completed implementation plan.
+
+### Threads
+
+- None; current source, history, Apple AVFoundation documentation, tests, and
+  the existing Skin observer pattern were reviewed directly.
+
+### Files changed
+
+- `ScreenShare/Document.swift` — event-driven aspect updates.
+- `scripts/check-screenshare-source.py` and
+  `scripts/test-screenshare-contracts.py` — regression and mutation coverage.
+- `AGENTS.md`, `README.md`, `SECURITY.md`, and `VISION.md` — maintained behavior
+  contract.
+- `docs/plans/2026-06-26-document-format-observer-design.md` and
+  `docs/plans/2026-06-26-document-format-observer.md` — design and execution
+  evidence.
+
+### Validation
+
+- RED focused behavior gate — rejected the timer and missing observer lifecycle.
+- GREEN focused behavior gate — passed after the notification implementation.
+- Three isolated observer/guidance-removal mutations — rejected.
+- `make check` and an external absolute-Make invocation — passed 66 Make
+  target/authority cases, project and behavior checks, and 10 Python mutation
+  tests; local Xcode compilation skipped because `xcodebuild` is unavailable.
+- Hosted unsigned macOS compilation — required before merge.
+
+### Bugs / findings
+
+- P2 efficiency/lifecycle: the document woke every second indefinitely even
+  though AVFoundation exposes the exact format-change event.
+
+### Blockers
+
+- Physical-device orientation changes still require manual iPhone/iPad
+  verification; hosted compilation cannot exercise that hardware boundary.
+
+### Next action
+
+- Run complete local and hosted verification, then merge only the reviewed
+  exact head.
+
 ## 2026-06-26
 
 ### ScreenShare device setup and lifecycle guide

--- a/README.md
+++ b/README.md
@@ -180,8 +180,9 @@ steps above for that hardware boundary.
   capture skin is started or recorded as an active device session.
 - Static behavior checks also require device refreshes to guard the main
   device-list window before hiding or showing it.
-- Static behavior checks also require document aspect timers to be replaced and
-  invalidated when their windows close.
+- Document aspect updates run once after session start and then only for the
+  active input port's format-change notifications; device switches replace the
+  observer and window teardown removes it.
 - Static behavior checks also reject force-casting the application delegate and
   require skin selection/settings coordination to tolerate unavailable state.
 - Static project checks also require completed canonical plans under `docs/plans`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,8 +51,9 @@ cannot host its capture skin.
   test bundle cannot collide with the application module output.
 - CI actions stay pinned by commit, run with read-only repository contents
   permission, and disable checkout credential persistence.
-- Closing a document must invalidate its repeating preview timer so retired
-  capture UI is not retained or updated after teardown.
+- Document aspect updates run once after session start and then only for the
+  active input port's format-change notifications; device switches replace the
+  observer and window teardown removes it so retired capture UI is not updated.
 - Capture skins must conditionally resolve the application delegate so unusual
   nib or application lifecycle state cannot trigger a force-cast crash.
 - Newly discovered capture devices must create settings without a failable

--- a/ScreenShare/Document.swift
+++ b/ScreenShare/Document.swift
@@ -26,7 +26,7 @@ class Document: NSDocument {
     dynamic var devices : [AVCaptureDevice] = []
     
     let notifications = NotificationManager()
-    private var aspectTimer: Timer?
+    let formatNotifications = NotificationManager()
     
     override init() {
         super.init()
@@ -72,11 +72,7 @@ class Document: NSDocument {
         previewViewLayer.addSublayer(newPreviewLayer)
         
         self.session.startRunning()
-
-        // Update Aspect will run recurrently to account for changes in orientation we cannot catch
-        // TODO: Optimize to only do this for ios devices and listening for changes to the formatDescription of the video AVCaptureInputPort associated with the device.
-        aspectTimer?.invalidate()
-        aspectTimer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(updateAspect), userInfo: nil, repeats: true)
+        self.updateAspect()
         
     }
     
@@ -117,6 +113,7 @@ class Document: NSDocument {
             self.session.beginConfiguration()
             defer {
                 self.session.commitConfiguration()
+                self.replaceFormatObserver()
                 self.updateAspect()
             }
 
@@ -144,6 +141,20 @@ class Document: NSDocument {
             self.session.addInput(replacementInput)
             self.input = replacementInput
         }
+    }
+
+    private func replaceFormatObserver() {
+        formatNotifications.deregisterAll()
+        guard let port = self.input?.ports.first else {
+            return
+        }
+        formatNotifications.registerObserver(
+            AVCaptureInput.Port.formatDescriptionDidChangeNotification,
+            forObject: port,
+            dispatchAsyncToMainQueue: true,
+            block: { [weak self] _ in
+                self?.updateAspect()
+        })
     }
     
     @objc func updateAspect() {
@@ -212,8 +223,7 @@ class Document: NSDocument {
     }
     
     func windowWillClose(_ notification: Notification) {
-        aspectTimer?.invalidate()
-        aspectTimer = nil
+        formatNotifications.deregisterAll()
         self.session.stopRunning()
         self.notifications.deregisterAll()
     }

--- a/VISION.md
+++ b/VISION.md
@@ -39,7 +39,9 @@ Priority:
 - Keep Skin pointer and window guards around drag and settings persistence callbacks
 - Replace format observers across capture retries and device switches
 - Keep the unsigned macOS unit-test wrapper executable on current Xcode
-- Release repeating preview timers when document windows close
+- Document aspect updates run once after session start and then only for the
+  active input port's format-change notifications; device switches replace the
+  observer and window teardown removes it
 - Keep session window setup tolerant of missing screen or content-view state
 - Register device sessions only after their capture skin can attach to a window
 - Keep device refreshes tolerant of missing main window outlet state

--- a/docs/plans/2026-06-26-document-format-observer-design.md
+++ b/docs/plans/2026-06-26-document-format-observer-design.md
@@ -1,0 +1,56 @@
+# Document Format Observer Design
+
+## Status: Completed
+
+## Current state
+
+`Document.windowControllerDidLoadNib(_:)` starts a repeating one-second timer
+that calls `updateAspect()`. The timer keeps aspect changes visible, but it also
+wakes every second when the input format is unchanged. `Skin` already solves
+the same lifecycle problem with a dedicated `NotificationManager` scoped to
+the active input port.
+
+Apple documents
+`AVCaptureInput.Port.formatDescriptionDidChangeNotification` as the event sent
+when a port's format description changes, with the changed port as the
+notification object.
+
+## Options considered
+
+1. Keep polling, but only for muxed/iOS devices. This reduces some work while
+   retaining a timer, device-type branching, and delayed updates.
+2. Replace polling with the port-format notification. Refresh once immediately
+   after session start, then react only when the active port changes format.
+3. Keep a timer as a fallback behind the notification. This preserves redundant
+   work and hides observer lifecycle defects instead of testing them.
+
+## Decision
+
+Use option 2 and mirror the existing `Skin` ownership pattern:
+
+- give `Document` a separate format-notification manager;
+- replace its observer after every selected-input transaction, including
+  rollback or clearing;
+- observe only the active input port and dispatch UI work to the main queue;
+- perform one immediate aspect refresh after the capture session starts; and
+- remove the obsolete timer and deregister the format observer at teardown.
+
+This keeps initial layout deterministic, avoids stale-device callbacks after a
+switch, and eliminates periodic work when the stream format is stable.
+
+## Validation
+
+- Add a source contract that fails while the repeating timer remains or the
+  active-port observer lifecycle is absent.
+- Add hostile repository-copy mutations for observer replacement and callback
+  registration.
+- Run all Make aliases and the hosted unsigned macOS build.
+
+The implementation plan records the `make check` verification evidence.
+
+## Evidence
+
+- Apple documentation:
+  <https://developer.apple.com/documentation/AVFoundation/AVCaptureInput/Port/formatDescriptionDidChangeNotification>
+- Existing repository precedent: `ScreenShare/Skin.swift` owns and replaces a
+  dedicated format observer when its selected device changes.

--- a/docs/plans/2026-06-26-document-format-observer.md
+++ b/docs/plans/2026-06-26-document-format-observer.md
@@ -1,0 +1,100 @@
+# Document Format Observer Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace `Document`'s repeating aspect timer with active-port format-change notifications while preserving immediate initial layout and safe device switching.
+
+**Architecture:** Reuse the repository's `NotificationManager` and the observer lifecycle already implemented by `Skin`. A dedicated manager owns exactly one active-port observer, replacement happens after each capture-session configuration transaction, and window teardown removes the observer.
+
+**Tech Stack:** Swift 5, AppKit, AVFoundation, Python source-contract tests, XCTest/Xcode hosted build.
+
+---
+
+## Status: Completed
+
+### Task 1: Define the observer contract
+
+**Files:**
+- Modify: `scripts/check-screenshare-source.py`
+- Test: `scripts/test-screenshare-contracts.py`
+
+**Step 1: Write the failing test**
+
+Require `Document` to own a format-notification manager, replace the observer
+after selected-input transactions, register the active port's
+`formatDescriptionDidChangeNotification`, refresh once after session start,
+and contain no repeating aspect timer.
+
+**Step 2: Run test to verify it fails**
+
+Run: `make test`
+
+Expected: FAIL because `Document` still owns and schedules `aspectTimer` and
+does not own an active-port observer.
+
+### Task 2: Replace polling with notifications
+
+**Files:**
+- Modify: `ScreenShare/Document.swift`
+
+**Step 1: Write minimal implementation**
+
+Add `formatNotifications`, call `replaceFormatObserver()` after each selected
+device transaction, register the current port with a weak main-queue callback,
+call `updateAspect()` immediately after session start, and deregister the
+format observer when the window closes.
+
+**Step 2: Run test to verify it passes**
+
+Run: `make test`
+
+Expected: PASS.
+
+### Task 3: Preserve mutation coverage and guidance
+
+**Files:**
+- Modify: `scripts/test-screenshare-contracts.py`
+- Modify: `AGENTS.md`
+- Modify: `README.md`
+- Modify: `SECURITY.md`
+- Modify: `VISION.md`
+- Modify: `CHANGES.md`
+- Modify: `docs/plans/2026-06-26-document-format-observer.md`
+
+**Step 1: Add hostile mutations**
+
+Remove observer replacement and active-port registration independently and
+verify the behavior contract rejects both repository copies.
+
+**Step 2: Synchronize durable guidance**
+
+Document that `Document` refreshes aspect state immediately and thereafter only
+for the active port's format-change notifications.
+
+**Step 3: Run complete verification**
+
+Run: `make lint && make test && make build && make check`
+
+Expected: all portable contracts pass; Xcode builds locally when available and
+the hosted macOS job remains required on Linux.
+
+**Step 4: Commit**
+
+```bash
+git add ScreenShare/Document.swift scripts/check-screenshare-source.py scripts/test-screenshare-contracts.py AGENTS.md README.md SECURITY.md VISION.md CHANGES.md docs/plans/2026-06-26-document-format-observer-design.md docs/plans/2026-06-26-document-format-observer.md
+git commit -m "fix: observe document input format changes"
+```
+
+## Verification Completed
+
+- The focused behavior contract failed against the repeating timer and missing
+  active-port observer, then passed after the event-driven lifecycle landed.
+- Two isolated hostile repository copies were rejected when observer
+  replacement or notification registration was removed.
+- A third hostile repository copy was rejected when synchronized public
+  guidance was removed.
+- `make check` and an external absolute-Make invocation passed 66 Make
+  target/authority cases, project and behavior checks, and all 10 Python
+  mutation tests.
+- Local Xcode compilation skipped because `xcodebuild` is unavailable; the
+  hosted unsigned macOS build remains required before merge.

--- a/scripts/check-screenshare-source.py
+++ b/scripts/check-screenshare-source.py
@@ -319,6 +319,8 @@ def project_checks():
             errors.append(f"{doc_path} must document Skin pointer and window guards")
         if "initial skin sessions reject unattached capture devices before window and view attachment" not in document.lower():
             errors.append(f"{doc_path} must document initial Skin attachment rejection")
+        if "document aspect updates run once after session start and then only for the active input port's format-change notifications" not in document.lower():
+            errors.append(f"{doc_path} must document event-driven Document aspect updates")
     if str(SKIN_PREVIEW_WINDOW_PLAN.relative_to(ROOT)) not in read_text("README.md"):
         errors.append(f"README.md must reference {SKIN_PREVIEW_WINDOW_PLAN.relative_to(ROOT)}")
     if "Skin capture device switch rollback preserves the prior working input" not in read_text("AGENTS.md"):
@@ -326,6 +328,8 @@ def project_checks():
     agents = re.sub(r"\s+", " ", read_text("AGENTS.md"))
     if "Initial Skin sessions reject unattached capture devices before window and view attachment" not in agents:
         errors.append("AGENTS.md must document initial Skin attachment rejection")
+    if "Document aspect updates run once after session start and then only for the active input port's format-change notifications" not in agents:
+        errors.append("AGENTS.md must document event-driven Document aspect updates")
 
     project = read_text("Screenshare.xcodeproj/project.pbxproj")
     for fragment in (
@@ -456,12 +460,30 @@ def behavior_checks():
         errors.append("Document.updateAspect must optional-bind the document window")
     if "private func resetResolutionStatus()" not in document:
         errors.append("Document.updateAspect must centralize resolution fallback state")
-    if "private var aspectTimer: Timer?" not in document:
-        errors.append("Document must retain its repeating aspect timer for teardown")
-    if "aspectTimer?.invalidate()\n        aspectTimer = Timer.scheduledTimer" not in document:
-        errors.append("Document preview setup must replace any existing aspect timer")
-    if "aspectTimer?.invalidate()\n        aspectTimer = nil\n        self.session.stopRunning()" not in document:
-        errors.append("Document window teardown must invalidate and release the aspect timer")
+    if "let formatNotifications = NotificationManager()" not in document:
+        errors.append("Document must own active-port format notifications separately")
+    if "aspectTimer" in document or "Timer.scheduledTimer" in document:
+        errors.append("Document must not poll for capture format changes")
+    if "self.session.startRunning()\n        self.updateAspect()" not in document:
+        errors.append("Document must refresh aspect state immediately after session start")
+    if "self.session.commitConfiguration()\n                self.replaceFormatObserver()\n                self.updateAspect()" not in document:
+        errors.append("Document device transactions must replace the active-port format observer")
+    replace_format_start = document.find("private func replaceFormatObserver()")
+    update_aspect_start = document.find("@objc func updateAspect()", replace_format_start)
+    replace_format_observer = document[replace_format_start:update_aspect_start]
+    for fragment in (
+        "private func replaceFormatObserver()",
+        "formatNotifications.deregisterAll()",
+        "AVCaptureInput.Port.formatDescriptionDidChangeNotification",
+        "forObject: port",
+        "dispatchAsyncToMainQueue: true",
+        "block: { [weak self] _ in",
+        "self?.updateAspect()",
+    ):
+        if min(replace_format_start, update_aspect_start) < 0 or fragment not in replace_format_observer:
+            errors.append(f"Document format observer must preserve {fragment!r}")
+    if "formatNotifications.deregisterAll()\n        self.session.stopRunning()" not in document:
+        errors.append("Document window teardown must release active-port format notifications")
     if re.search(r'print\("Using (Portrait|Landscape) settings', device):
         errors.append("Device saved settings must not log device names or saved window rectangles")
     if "NSLog(self.device.skin)" in skin:
@@ -655,8 +677,8 @@ def behavior_checks():
         errors.append("Document.refreshDevices must not nest capture session configuration")
     if "let replacementInput: AVCaptureDeviceInput?" not in document or "replacementInput = try AVCaptureDeviceInput(device: newDevice)" not in document:
         errors.append("Document.selectedDevice must construct the replacement input before mutating the session")
-    if "defer {\n                self.session.commitConfiguration()\n                self.updateAspect()\n            }" not in document:
-        errors.append("Document.selectedDevice must commit its single configuration transaction and refresh aspect state")
+    if "defer {\n                self.session.commitConfiguration()\n                self.replaceFormatObserver()\n                self.updateAspect()\n            }" not in document:
+        errors.append("Document.selectedDevice must commit its transaction, replace the format observer, and refresh aspect state")
     if "guard self.session.canAddInput(replacementInput) else" not in document:
         errors.append("Document.selectedDevice must validate replacement input admission")
     if "self.session.canAddInput(previousInput)" not in document or "self.session.addInput(previousInput)\n                    self.input = previousInput" not in document:

--- a/scripts/test-screenshare-contracts.py
+++ b/scripts/test-screenshare-contracts.py
@@ -103,6 +103,55 @@ class ContractMutationTests(unittest.TestCase):
             "Skin device changes must replace the format observer instead of accumulating callbacks",
         )
 
+    def test_rejects_document_format_observer_replacement_removal(self):
+        repository = self.copy_repository()
+        self.mutate(
+            repository,
+            "ScreenShare/Document.swift",
+            "                self.replaceFormatObserver()\n",
+            "",
+        )
+        self.assert_behavior_rejects(
+            repository,
+            "Document device transactions must replace the active-port format observer",
+        )
+
+    def test_rejects_document_format_notification_registration_removal(self):
+        repository = self.copy_repository()
+        self.mutate(
+            repository,
+            "ScreenShare/Document.swift",
+            "            AVCaptureInput.Port.formatDescriptionDidChangeNotification,\n",
+            "",
+        )
+        self.assert_behavior_rejects(
+            repository,
+            "Document format observer must preserve 'AVCaptureInput.Port.formatDescriptionDidChangeNotification'",
+        )
+
+    def test_rejects_document_aspect_guidance_removal(self):
+        repository = self.copy_repository()
+        self.mutate(
+            repository,
+            "README.md",
+            "- Document aspect updates run once after session start and then only for the\n  active input port's format-change notifications; device switches replace the\n  observer and window teardown removes it.\n",
+            "",
+        )
+        result = subprocess.run(
+            [
+                str(repository / "scripts/run-python.sh"),
+                "scripts/check-screenshare-source.py",
+                "--mode",
+                "project",
+            ],
+            cwd=repository,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertNotEqual(0, result.returncode, result.stdout)
+        self.assertIn("README.md must document event-driven Document aspect updates", result.stderr)
+
     def test_rejects_colliding_unit_test_module_name(self):
         repository = self.copy_repository()
         self.mutate(


### PR DESCRIPTION
## Summary

- Replace the repeating document aspect timer with the active input port format-change notification.
- Refresh aspect state immediately after session start and replace observers across device transactions.
- Add scoped contracts, hostile mutations, synchronized guidance, and completed design/implementation evidence.

## Baseline

Document aspect state was refreshed by a repeating timer instead of observing the active capture input's format changes, creating unnecessary polling and lifecycle cleanup complexity.

## Improvements

- **Reliability:** Refresh aspect state once at start and on active input format changes.
- **Architecture:** Scope observer ownership to the current input port and replace/remove it during device switches and teardown.
- **Tests:** Added three hostile observer-lifecycle mutations and focused behavior contracts.
- **Documentation:** Recorded the observer design, implementation evidence, and device verification boundary.

## Validation

- `make lint`, `make test`, `make verify`, and `make check` passed.
- `make build` passed static checks locally; `xcodebuild` was unavailable on Linux.
- External `/usr/bin/make -f /tmp/code/ScreenShare/Makefile check` passed.
- Shell syntax, Python compilation, and `git diff --check` passed.
- Exact-head hosted macOS `build` and `contract` checks succeeded.

## Risk

Aspect updates now depend on the capture input port's format-change notification and correct observer replacement. Physical-device format transitions and live mirroring still require compatible Apple hardware.

## Follow-Ups

Exercise device rotation, resolution changes, disconnect, reconnect, and device switching on an unlocked trusted iPhone or iPad.
