### PR TITLE
fix: select capture video ports explicitly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,8 @@
 - Document aspect updates run once after session start and then only for the
   active input port's format-change notifications; device switches replace the
   observer and window teardown removes it.
+- Document and Skin select the explicit video port instead of relying on
+  capture input port ordering.
 - See `docs/plans/2026-06-08-device-archive-decoding.md` for the local device-settings archive guard.
 
 ## Agent workflow

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changes
 
-## 2026-06-27 - P1 - Select capture video ports explicitly
+## 2026-06-26 17:40 PDT - P1 - Select capture video ports explicitly
 
 ### Summary
 
@@ -16,7 +16,19 @@ port as video when a muxed device can expose separate media streams.
 - Added a red-first behavior contract and a hostile unfiltered-port mutation.
 - Synchronized maintained runtime and security guidance.
 
-### Evidence
+### Files changed
+
+- `ScreenShare/Extensions.swift` — shared filtered video-port selector.
+- `ScreenShare/Document.swift` and `ScreenShare/Skin.swift` — observer and
+  dimension lookups routed through the selector.
+- `scripts/check-screenshare-source.py` and
+  `scripts/test-screenshare-contracts.py` — source contract and hostile
+  mutation coverage.
+- `AGENTS.md`, `README.md`, `SECURITY.md`, `VISION.md`, and
+  `docs/plans/2026-06-27-explicit-video-port-selection.md` — maintained
+  behavior, security, and implementation evidence.
+
+### Validation
 
 - Apple AVFoundation documentation states that a capture input can provide one
   or more streams and represents each stream with its own input port.
@@ -28,10 +40,18 @@ port as video when a muxed device can expose separate media streams.
 - Native Xcode compilation is unavailable on this Linux host; hosted unsigned
   macOS compilation remains required on the exact PR head.
 
+### Bugs / findings
+
+- P1 correctness: `ports.first` can resolve a non-video stream on muxed capture
+  devices, causing format observers and dimensions to follow the wrong port.
+- Manual review found no additional source defects in the focused diff.
+
 ### Blockers
 
 - Live muxed-device ordering and format transitions still require compatible
   trusted iPhone/iPad hardware; hosted builds validate compilation only.
+- `codex review --base origin/master` could not authenticate and returned HTTP
+  401, so the required review attempt was skipped after one invocation.
 
 ### Next action
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,43 @@
 # Changes
 
+## 2026-06-27 - P1 - Select capture video ports explicitly
+
+### Summary
+
+Stopped Document and Skin aspect handling from treating the first capture input
+port as video when a muxed device can expose separate media streams.
+
+### Work completed
+
+- Added a shared `.video`-filtered `AVCaptureDeviceInput.videoPort` selector.
+- Document and Skin select the explicit video port instead of relying on
+  capture input port ordering.
+- Routed both format observers and both dimension readers through that selector.
+- Added a red-first behavior contract and a hostile unfiltered-port mutation.
+- Synchronized maintained runtime and security guidance.
+
+### Evidence
+
+- Apple AVFoundation documentation states that a capture input can provide one
+  or more streams and represents each stream with its own input port.
+- The focused gate failed before implementation on the missing selector and all
+  four `ports.first` call sites, then passed with 11 mutation tests.
+- `make check` passed 66 Make target/authority cases, project and behavior
+  checks, and all 11 mutation tests from the checkout and `/tmp`.
+- Python compilation, shell syntax, and `git diff --check` passed.
+- Native Xcode compilation is unavailable on this Linux host; hosted unsigned
+  macOS compilation remains required on the exact PR head.
+
+### Blockers
+
+- Live muxed-device ordering and format transitions still require compatible
+  trusted iPhone/iPad hardware; hosted builds validate compilation only.
+
+### Next action
+
+- Run complete local and hosted verification, review the exact head, and merge
+  only if every maintained gate remains green.
+
 ## 2026-06-26 06:52 PDT - P2 - replace document aspect polling
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ steps above for that hardware boundary.
 - Document aspect updates run once after session start and then only for the
   active input port's format-change notifications; device switches replace the
   observer and window teardown removes it.
+- Document and Skin select the explicit video port instead of relying on
+  capture input port ordering when observing or measuring format changes.
 - Static behavior checks also reject force-casting the application delegate and
   require skin selection/settings coordination to tolerate unavailable state.
 - Static project checks also require completed canonical plans under `docs/plans`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,6 +54,9 @@ cannot host its capture skin.
 - Document aspect updates run once after session start and then only for the
   active input port's format-change notifications; device switches replace the
   observer and window teardown removes it so retired capture UI is not updated.
+- Document and Skin select the explicit video port instead of relying on
+  capture input port ordering, so muxed audio streams cannot drive video
+  dimensions or observer ownership.
 - Capture skins must conditionally resolve the application delegate so unusual
   nib or application lifecycle state cannot trigger a force-cast crash.
 - Newly discovered capture devices must create settings without a failable

--- a/ScreenShare/Document.swift
+++ b/ScreenShare/Document.swift
@@ -145,7 +145,7 @@ class Document: NSDocument {
 
     private func replaceFormatObserver() {
         formatNotifications.deregisterAll()
-        guard let port = self.input?.ports.first else {
+        guard let port = self.input?.videoPort else {
             return
         }
         formatNotifications.registerObserver(
@@ -159,7 +159,7 @@ class Document: NSDocument {
     
     @objc func updateAspect() {
         
-        guard let port = self.input?.ports.first,
+        guard let port = self.input?.videoPort,
             let window = self.windowForSheet,
             let description = port.formatDescription else {
                 resetResolutionStatus()

--- a/ScreenShare/Extensions.swift
+++ b/ScreenShare/Extensions.swift
@@ -3,6 +3,13 @@
 //
 
 import Foundation
+import AVFoundation
+
+extension AVCaptureDeviceInput {
+    var videoPort: AVCaptureInput.Port? {
+        return ports.first { $0.mediaType == .video }
+    }
+}
 
 extension Int {
     func format(_ f: String) -> String {

--- a/ScreenShare/Skin.swift
+++ b/ScreenShare/Skin.swift
@@ -205,7 +205,7 @@ class Skin: NSView {
 
     private func replaceFormatObserver() {
         formatNotifications.deregisterAll()
-        guard let port = self.input?.ports.first else {
+        guard let port = self.input?.videoPort else {
             return
         }
         formatNotifications.registerObserver(
@@ -221,7 +221,7 @@ class Skin: NSView {
         
         // let window = self.windowForSheet
         if( window != nil) {
-            if let port = self.input?.ports.first {
+            if let port = self.input?.videoPort {
                 
                 if let description = port.formatDescription {
                     deviceDimensionsObtained = true

--- a/VISION.md
+++ b/VISION.md
@@ -42,6 +42,8 @@ Priority:
 - Document aspect updates run once after session start and then only for the
   active input port's format-change notifications; device switches replace the
   observer and window teardown removes it
+- Document and Skin select the explicit video port instead of relying on
+  capture input port ordering
 - Keep session window setup tolerant of missing screen or content-view state
 - Register device sessions only after their capture skin can attach to a window
 - Keep device refreshes tolerant of missing main window outlet state

--- a/docs/plans/2026-06-27-explicit-video-port-selection.md
+++ b/docs/plans/2026-06-27-explicit-video-port-selection.md
@@ -1,0 +1,34 @@
+# Select capture video ports explicitly
+
+Status: Completed
+
+## Problem
+
+`Document` and `Skin` observed and measured `input.ports.first`. Apple documents
+that one capture input can provide multiple media streams, each represented by
+its own port. A muxed device can therefore expose audio and video ports without
+promising that the video stream is first.
+
+References:
+
+- <https://developer.apple.com/documentation/avfoundation/avcaptureinput>
+- <https://developer.apple.com/documentation/avfoundation/avcaptureinput/port>
+
+## Fix
+
+- Add one `AVCaptureDeviceInput.videoPort` selector filtered by `.video`.
+- Use that port for Document and Skin format notifications and dimensions.
+- Fail closed to the existing unavailable-dimensions behavior when no video
+  stream exists.
+
+## Test First
+
+The focused behavior gate failed because no filtered video-port selector
+existed and both capture paths still depended on `ports.first`.
+
+## Verification
+
+- Run `make test` for the focused source contract and hostile mutation.
+- Run `make check` from the checkout and an external working directory.
+- Run Python compilation, shell syntax checks, and `git diff --check`.
+- Require hosted unsigned macOS compilation and CodeQL on the exact PR head.

--- a/scripts/check-screenshare-source.py
+++ b/scripts/check-screenshare-source.py
@@ -321,6 +321,8 @@ def project_checks():
             errors.append(f"{doc_path} must document initial Skin attachment rejection")
         if "document aspect updates run once after session start and then only for the active input port's format-change notifications" not in document.lower():
             errors.append(f"{doc_path} must document event-driven Document aspect updates")
+        if "document and skin select the explicit video port instead of relying on capture input port ordering" not in document.lower():
+            errors.append(f"{doc_path} must document explicit video-port selection")
     if str(SKIN_PREVIEW_WINDOW_PLAN.relative_to(ROOT)) not in read_text("README.md"):
         errors.append(f"README.md must reference {SKIN_PREVIEW_WINDOW_PLAN.relative_to(ROOT)}")
     if "Skin capture device switch rollback preserves the prior working input" not in read_text("AGENTS.md"):
@@ -330,6 +332,8 @@ def project_checks():
         errors.append("AGENTS.md must document initial Skin attachment rejection")
     if "Document aspect updates run once after session start and then only for the active input port's format-change notifications" not in agents:
         errors.append("AGENTS.md must document event-driven Document aspect updates")
+    if "Document and Skin select the explicit video port instead of relying on capture input port ordering" not in agents:
+        errors.append("AGENTS.md must document explicit video-port selection")
 
     project = read_text("Screenshare.xcodeproj/project.pbxproj")
     for fragment in (
@@ -454,8 +458,21 @@ def behavior_checks():
         errors.append("Document.updateAspect must not force unwrap the input port")
     if "let windowFrame = window!.frame" in document:
         errors.append("Document.updateAspect must not force unwrap the document window")
-    if "guard let port = self.input?.ports.first" not in document:
-        errors.append("Document.updateAspect must optional-bind the capture input port")
+    for fragment in (
+        "extension AVCaptureDeviceInput",
+        "var videoPort: AVCaptureInput.Port?",
+        "ports.first { $0.mediaType == .video }",
+    ):
+        if fragment not in extensions:
+            errors.append(f"capture inputs must select their video stream via {fragment!r}")
+    if "self.input?.ports.first" in document or "self.input?.ports.first" in skin:
+        errors.append("capture aspect handling must not rely on input-port ordering")
+    if document.count("self.input?.videoPort") < 2:
+        errors.append("Document must observe and measure the explicit video input port")
+    if skin.count("self.input?.videoPort") < 2:
+        errors.append("Skin must observe and measure the explicit video input port")
+    if "guard let port = self.input?.videoPort" not in document:
+        errors.append("Document.updateAspect must optional-bind the video capture input port")
     if "let window = self.windowForSheet" not in document:
         errors.append("Document.updateAspect must optional-bind the document window")
     if "private func resetResolutionStatus()" not in document:

--- a/scripts/test-screenshare-contracts.py
+++ b/scripts/test-screenshare-contracts.py
@@ -103,6 +103,19 @@ class ContractMutationTests(unittest.TestCase):
             "Skin device changes must replace the format observer instead of accumulating callbacks",
         )
 
+    def test_rejects_unfiltered_capture_port_selection(self):
+        repository = self.copy_repository()
+        self.mutate(
+            repository,
+            "ScreenShare/Extensions.swift",
+            "ports.first { $0.mediaType == .video }",
+            "ports.first",
+        )
+        self.assert_behavior_rejects(
+            repository,
+            "capture inputs must select their video stream via 'ports.first { $0.mediaType == .video }'",
+        )
+
     def test_rejects_document_format_observer_replacement_removal(self):
         repository = self.copy_repository()
         self.mutate(


### PR DESCRIPTION
## Summary
- select the `.video` capture input port instead of relying on `ports.first`
- share the selector across Document and Skin observers/dimension reads
- add red-first source contracts, a hostile unfiltered-port mutation, and synchronized guidance

## Evidence
Apple documents that one capture input may expose multiple media streams, each represented by its own port:
- https://developer.apple.com/documentation/avfoundation/avcaptureinput
- https://developer.apple.com/documentation/avfoundation/avcaptureinput/port

## Validation
- `make test`
- `make check`
- `/usr/bin/make -C /tmp -f "$PWD/Makefile" check`
- Python compilation, shell syntax, and `git diff --check`
- Local native build skipped because `xcodebuild` is unavailable on Linux; hosted macOS build required
