### PR TITLE
fix: strip Swift comments before asserting source contracts

### DIFF
--- a/scripts/check-screenshare-source.py
+++ b/scripts/check-screenshare-source.py
@@ -461,10 +461,19 @@ def behavior_checks():
     format_observer_start = skin.find("private func replaceFormatObserver()")
     format_observer_end = skin.find("func getVideoDimensions()", format_observer_start)
     format_observer = skin[format_observer_start:format_observer_end]
+    # Pin the whole construct, not the bare call: asserting only that the literal appears
+    # somewhere in the method cannot tell a live deregister from a dead one. Wrapping the
+    # call in `if false { ... }` keeps the literal present and uncommented while observers
+    # accumulate again. Requiring the call to BE the first statement rejects that, using
+    # the same contiguous-literal form as archive_binding below.
+    deregister_first = (
+        "private func replaceFormatObserver() {\n"
+        "        formatNotifications.deregisterAll()\n"
+    )
     if (
         format_observer_start < 0
         or format_observer_end < 0
-        or "formatNotifications.deregisterAll()" not in format_observer
+        or deregister_first not in format_observer
         or "forObject: port" not in format_observer
     ):
         errors.append("Skin device changes must replace the format observer instead of accumulating callbacks")

--- a/scripts/check-screenshare-source.py
+++ b/scripts/check-screenshare-source.py
@@ -73,7 +73,100 @@ jobs:
 """
 
 
+# Ported verbatim from ios-app-share's check-baseline.py, the working reference in
+# this account: a real scanner handling nested /* */ blocks, string-aware and
+# escape-aware. A naive //[^\n]* regex would blank the rest of the line for
+# `let u = "https://example.com"` and fail a contract against correct source.
+#
+# Every "must contain" assertion below read Swift raw, so a commented-out call
+# satisfied its own assertion while the code was dead. Verified: block-commenting
+# formatNotifications.deregisterAll() inside replaceFormatObserver() left
+# `make check` at exit 0 -- the literal count in Skin.swift stayed at 2 while live
+# occurrences dropped to 1 -- reintroducing the accumulating-callback bug the gate
+# exists to prevent. Deleting the same call IS caught ("Skin device changes must
+# replace the format observer instead of accumulating callbacks"), so the gate was
+# live but blind.
+#
+# Note the pre-existing asymmetry this closes: the print/println scan below already
+# skips comment lines, because there a comment would cause a false POSITIVE. The
+# same awareness was absent from the "must contain" checks, where a comment causes
+# false ASSURANCE.
+def strip_swift_comments(text):
+    result = []
+    index = 0
+    block_depth = 0
+    in_string = False
+    escaped = False
+
+    while index < len(text):
+        character = text[index]
+        next_character = text[index + 1] if index + 1 < len(text) else ""
+
+        if block_depth:
+            if character == "/" and next_character == "*":
+                block_depth += 1
+                index += 2
+                continue
+            if character == "*" and next_character == "/":
+                block_depth -= 1
+                index += 2
+                continue
+            if character == "\n":
+                result.append(character)
+            index += 1
+            continue
+
+        if in_string:
+            result.append(character)
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                in_string = False
+            index += 1
+            continue
+
+        if character == '"':
+            in_string = True
+            result.append(character)
+            index += 1
+            continue
+        if character == "/" and next_character == "/":
+            newline = text.find("\n", index + 2)
+            if newline == -1:
+                break
+            result.append("\n")
+            index = newline + 1
+            continue
+        if character == "/" and next_character == "*":
+            block_depth = 1
+            index += 2
+            continue
+
+        result.append(character)
+        index += 1
+
+    return "".join(result)
+
+
 def read_text(relative_path):
+    """Read a file, blanking Swift comments so assertions see live code only.
+
+    Non-Swift files (README, plists, project files) are returned untouched.
+    """
+    text = (ROOT / relative_path).read_text(encoding="utf-8")
+    if str(relative_path).endswith(".swift"):
+        return strip_swift_comments(text)
+    return text
+
+
+def read_text_raw(relative_path):
+    """Read a file untouched, comments included.
+
+    Only for assertions genuinely ABOUT comment text. Code assertions must use
+    read_text(), or a commented-out call satisfies its own assertion.
+    """
     return (ROOT / relative_path).read_text(encoding="utf-8")
 
 

--- a/scripts/test-screenshare-contracts.py
+++ b/scripts/test-screenshare-contracts.py
@@ -103,6 +103,23 @@ class ContractMutationTests(unittest.TestCase):
             "Skin device changes must replace the format observer instead of accumulating callbacks",
         )
 
+    def test_rejects_neutered_format_observer_deregister(self):
+        # The deregister call kept present and uncommented, but never executed. Deleting
+        # the literal (above) and commenting it out are both caught by its absence from
+        # the source; this leaves the literal byte-identical, so only pinning the whole
+        # construct rejects it.
+        repository = self.copy_repository()
+        self.mutate(
+            repository,
+            "ScreenShare/Skin.swift",
+            "private func replaceFormatObserver() {\n        formatNotifications.deregisterAll()",
+            "private func replaceFormatObserver() {\n        if false {\n            formatNotifications.deregisterAll()\n        }",
+        )
+        self.assert_behavior_rejects(
+            repository,
+            "Skin device changes must replace the format observer instead of accumulating callbacks",
+        )
+
     def test_rejects_unfiltered_capture_port_selection(self):
         repository = self.copy_repository()
         self.mutate(


### PR DESCRIPTION
## Problem

Every "must contain" assertion read Swift source **raw**, so a commented-out call satisfies its own assertion while the code is dead.

## Reproduction

Block-commented `formatNotifications.deregisterAll()` inside `replaceFormatObserver()`:

```
literal count in Skin.swift  stayed at 2
live (uncommented) occurrences  dropped to 1
make check  exit 0
```

That reintroduces exactly the bug the gate exists to prevent: the format observer is added again without the previous one being deregistered — **accumulating callbacks**.

**Control, proving the gate is live rather than dead** — deleting the same call outright **is** caught:

```
Skin device changes must replace the format observer instead of accumulating callbacks
exit 2
```

## The asymmetry this closes

Worth flagging, because the repo **already knows** comments matter. The `print/println` scan at the bottom of `check-screenshare-source.py` skips them:

```python
if stripped.startswith("//") or stripped.startswith("/*") or stripped.startswith("*"):
    continue
```

There, a comment would cause a **false positive** — a commented-out `print()` flagged as a violation. So the author handled it.

That same awareness was **absent from every "must contain" check**, where a comment causes **false assurance** instead. Comment handling existed exactly where it prevented noise, and not where it prevented blindness.

## Fix

Ported **`ios-app-share`'s scanner verbatim** rather than writing another one — nested `/* */`, string-aware, escape-aware. `read_text()` now blanks comments for `.swift` and returns other files (README, plists, project files) untouched. Added `read_text_raw()` for any assertion genuinely *about* comment text.

The `print/println` scan reads raw lines itself and is unaffected — **verified it still fires** (exit 2 on an injected `print("leak")`).

## Verification

| Tree | Applied | Result |
|---|---|---|
| clean | — | exit **0** |
| `deregisterAll` in `replaceFormatObserver`, **block** comment | 1 | **CAUGHT** — `must replace the format observer instead of accumulating callbacks` |
| `deregisterAll` in `replaceFormatObserver`, **line** comment | 1 | **CAUGHT** |
| injected `print("leak")` | — | **CAUGHT** — `must not use print/println for app logging` (unaffected) |

Scanner self-tests **5/5**: block blanked · line blanked · **nested** blanked · URL-in-string kept · live code kept.

## Severity and honest bounds

**The shipped code is correct** — this is a verification gap, not a live defect. `replaceFormatObserver()` deregisters properly today.

**What I could not verify:** no `swift`/`swiftc`/`xcodebuild` and no macOS on this host, so I compiled no Swift and observed no runtime behaviour. Every result above is a real run of the Python gate — which is what runs here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
